### PR TITLE
add `Client.get_token` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * RS-177: Add license field to ServerInfo, [PR-1](https://github.com/reductstore/reduct-rs/pull/1)
 * RS-185: Add `verify_ssl` option¸ [PR-2](https://github.com/reductstore/reduct-rs/pull/2)
+* `Client.get_token` method, [PR-3](
 
 ## [1.8.0] - 2024-01-24
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -225,7 +225,7 @@ impl ReductClient {
             .await
     }
 
-    /// Create a tokem
+    /// Create an access token
     ///
     /// # Arguments
     ///
@@ -247,7 +247,22 @@ impl ReductClient {
         Ok(token.value)
     }
 
-    /// Delete a token
+    /// Get an access token
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the token
+    ///
+    /// # Returns
+    ///
+    /// The token or an error
+    pub async fn get_token(&self, name: &str) -> Result<Token> {
+        self.http_client
+            .send_and_receive_json::<(), Token>(Method::GET, &format!("/tokens/{}", name), None)
+            .await
+    }
+
+    /// Delete an access token
     ///
     /// # Arguments
     ///
@@ -264,7 +279,7 @@ impl ReductClient {
         Ok(())
     }
 
-    /// List all tokens
+    /// List all access tokens
     ///
     /// # Returns
     ///
@@ -488,6 +503,19 @@ pub(crate) mod tests {
                 .unwrap();
 
             assert!(token_value.starts_with("test-token"));
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_get_token(#[future] client: ReductClient) {
+            let token = client.await.get_token("init-token").await.unwrap();
+            assert_eq!(token.name, "init-token");
+            assert!(!token.is_provisioned);
+
+            let permissions = token.permissions.unwrap();
+            assert!(permissions.full_access);
+            assert!(permissions.read.is_empty());
+            assert!(permissions.write.is_empty());
         }
 
         #[rstest]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

I've added the forgotten `Client.get_token` method to get an access token by name.

### Related issues

### Does this PR introduce a breaking change?

### Other information:
