### PR TITLE
Fix sorting batched data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+* Fix sorting batched data, [PR-5](https://github.com/reductstore/reduct-rs/pull/5)
+
 ## [1.9.2] - 2024-03-08
 
 ### Fixed


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The SDK sorted headers in a batched request  as strings  without considering their lengths. So timestamps [1, 2, 10] were sorted as [1, 10, 2] but it is not how the server sends the data. I've fixed the sorting by casting the timestamps into integers. 

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
