### PR TITLE
Add `Send` and `Sync` traits to `Record.bytes()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 * Fix sorting batched data, [PR-5](https://github.com/reductstore/reduct-rs/pull/5)
+* Add Send and Sync traits to Record.bytes(), [PR-6](https://github.com/reductstore/reduct-rs/pull/6)
 
 ## [1.9.2] - 2024-03-08
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -81,7 +81,9 @@ impl Record {
     /// Content of the record
     ///
     /// This consumes the record and returns bytes
-    pub fn bytes(self) -> Pin<Box<dyn futures::Future<Output = Result<Bytes, ReductError>>>> {
+    pub fn bytes(
+        self,
+    ) -> Pin<Box<dyn futures::Future<Output = Result<Bytes, ReductError>> + Send + Sync>> {
         Box::pin(async move {
             if let Some(mut data) = self.data {
                 let mut bytes = BytesMut::new();


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

I've forgot to add this traits to use the `bytes()` method in threads. 

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
