### PR TITLE
Re-export replication structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.5] - 2024-03-30
+
+### Fixed
+
+* Re-export replication structures, [PR-7](https://github.com/reductstore/reduct-rs/pull/7)
+
 ## [1.9.4] - 2024-03-29
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,8 @@ pub use record::{Labels, Record, RecordBuilder, RecordStream};
 pub use reduct_base::error::{ErrorCode, ReductError};
 pub use reduct_base::msg::bucket_api::{BucketInfo, BucketSettings, FullBucketInfo, QuotaType};
 pub use reduct_base::msg::entry_api::EntryInfo;
+pub use reduct_base::msg::replication_api::{
+    FullReplicationInfo, ReplicationInfo, ReplicationList, ReplicationSettings,
+};
 pub use reduct_base::msg::server_api::{BucketInfoList, Defaults, ServerInfo};
 pub use reduct_base::msg::token_api::{Permissions, Token};


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Replication structures are re-exported from `reductstore-base`.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
