### PR TITLE
Use `IntoBody` and `IntoBytes` to write data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use IntoBody and `IntoBytes to write data, [PR-10](https://github.com/reductstore/reduct-rs/pull/10)
+
 ## [1.9.5] - 2024-03-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ async fn main() -> Result<(), ReductError> {
     bucket
         .write_record("entry-1")
         .timestamp(timestamp)
-        .data(Bytes::from("Hello, World!"))
+        .data("Hello, World!")
         .send()
         .await?;
 

--- a/examples/hallo_world.rs
+++ b/examples/hallo_world.rs
@@ -3,7 +3,6 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use bytes::Bytes;
 use reduct_rs::{ReductClient, ReductError};
 use std::str::from_utf8;
 use std::time::SystemTime;

--- a/examples/hallo_world.rs
+++ b/examples/hallo_world.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), ReductError> {
     bucket
         .write_record("entry-1")
         .timestamp(timestamp)
-        .data(Bytes::from("Hello, World!"))
+        .data("Hello, World!")
         .send()
         .await?;
 

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -19,14 +19,14 @@ async fn main() -> Result<(), ReductError> {
     bucket
         .write_record("entry-1")
         .add_label("planet", "Earth")
-        .data(Bytes::from("Hello, Earth!"))
+        .data("Hello, Earth!")
         .send()
         .await?;
 
     bucket
         .write_record("entry-1")
         .add_label("planet", "Mars")
-        .data(Bytes::from("Hello, Mars!"))
+        .data("Hello, Mars!")
         .send()
         .await?;
 

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -3,7 +3,6 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use bytes::Bytes;
 use futures_util::StreamExt;
 use reduct_rs::{ReductClient, ReductError};
 use std::str::from_utf8;

--- a/src/record.rs
+++ b/src/record.rs
@@ -157,6 +157,8 @@ impl RecordBuilder {
     }
 
     /// Set the content length of the record to write
+    ///
+    /// Note: use this with stream data
     pub fn content_length(mut self, content_length: usize) -> Self {
         self.record.content_length = content_length;
         self
@@ -164,8 +166,12 @@ impl RecordBuilder {
 
     /// Set the content of the record
     ///
-    /// Overwrites content length
-    pub fn data(mut self, bytes: Bytes) -> Self {
+    /// Note: use this with data that fits in memory
+    pub fn data<D>(mut self, data: D) -> Self
+    where
+        D: Into<Bytes>,
+    {
+        let bytes = data.into();
         self.record.content_length = bytes.len();
         self.record.data = Some(Box::pin(futures::stream::once(async move { Ok(bytes) })));
         self

--- a/src/record/write_record.rs
+++ b/src/record/write_record.rs
@@ -80,7 +80,14 @@ impl WriteRecordBuilder {
     }
 
     /// Set the data of the record to write.
-    pub fn data(mut self, data: Bytes) -> Self {
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data to write.
+    pub fn data<B>(mut self, data: B) -> Self
+    where
+        B: Into<Body>,
+    {
         self.data = Some(data.into());
         self
     }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Instead of using `Bytes` implicitly as the data format, we use `IntoBody` and `IntoBytes` traits in generic methods:

Before:

```rust
   bucket
        .write_record("entry-1")
        .timestamp(timestamp)
        .data(Bytes::from("Hello, World!"))
        .send()
        .await?;
```

Now

```rust
   bucket
        .write_record("entry-1")
        .timestamp(timestamp)
        .data("Hello, World!")
        .send()
        .await?;
```

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
