### PR TITLE
RS-261: Add each_n and each_s query parameters 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
     strategy:
       matrix:
         reductstore_version: [ "main", "latest" ]
+        include:
+          - reductstore_version: main
+            features: "test-api-110"
+          - reductstore_version: latest
+            features: ""
     needs:
       - rust_fmt
     steps:
@@ -47,7 +52,7 @@ jobs:
           --env RS_API_TOKEN=TOKEN
           --env RS_LICENSE_PATH=/misc/lic.key -d reduct/store:${{ matrix.reductstore_version }}
       - name: Run Client SDK tests
-        run: RS_API_TOKEN=TOKEN cargo test -- --test-threads=1
+        run: RS_API_TOKEN=TOKEN cargo test --features ${{ matrix.features }} -- --test-threads=1
 
   sdk_examples:
     name: Client SDK Examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
         reductstore_version: [ "main", "latest" ]
         include:
           - reductstore_version: main
-            features: "test-api-110"
+            features: "default test-api-110"
           - reductstore_version: latest
-            features: ""
+            features: "default"
     needs:
       - rust_fmt
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
   sdk_tests:
     name: Client SDK Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        reductstore_version: [ "main", "latest" ]
     needs:
       - rust_fmt
     steps:
@@ -42,7 +45,7 @@ jobs:
       - name: Run Database
         run: docker run --network=host -v ${PWD}/misc:/misc
           --env RS_API_TOKEN=TOKEN
-          --env RS_LICENSE_PATH=/misc/lic.key -d ${{env.REGISTRY_IMAGE}}
+          --env RS_LICENSE_PATH=/misc/lic.key -d reduct/store:${{ matrix.reductstore_version }}
       - name: Run Client SDK tests
         run: RS_API_TOKEN=TOKEN cargo test -- --test-threads=1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- RS-261: Add `each_n` and `each_s` query parameters, [PR-11](https://github.com/reductstore/reduct-rs/pull/11)
+
 ### Changed
 
 - Use IntoBody and `IntoBytes to write data, [PR-10](https://github.com/reductstore/reduct-rs/pull/10)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 keywords = ["database", "time-series", "client", "sdk", "reductstore"]
 categories = ["database"]
 
+[features]
+default = []
+test-api-110 = []   # Test API 1.10
+
 
 [lib]
 crate-type = ["lib"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ database for unstructured data.
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.8](https://reduct.store/docs/http-api)
+* Supports the [ReductStore HTTP API v1.10](https://reduct.store/docs/http-api)
 * Built on top of [reqwest](https://github.com/seanmonstar/reqwest)
 * Asynchronous API
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -725,7 +725,22 @@ pub(crate) mod tests {
                 ("entry".into(), "2".into()),
                 ("bucket".into(), "1".into()),
             ]))
-            .data(Bytes::from("Hey entry-2#1!"))
+            .data(Bytes::from("Hey entry-2!"))
+            .send()
+            .await
+            .unwrap();
+
+        bucket
+            .write_record("entry-2")
+            .timestamp_us(3000)
+            .data("0")
+            .send()
+            .await
+            .unwrap();
+        bucket
+            .write_record("entry-2")
+            .timestamp_us(4000)
+            .data("0")
             .send()
             .await
             .unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -725,7 +725,7 @@ pub(crate) mod tests {
                 ("entry".into(), "2".into()),
                 ("bucket".into(), "1".into()),
             ]))
-            .data(Bytes::from("Hey entry-2!"))
+            .data(Bytes::from("Hey entry-2#1!"))
             .send()
             .await
             .unwrap();

--- a/src/record/write_record.rs
+++ b/src/record/write_record.rs
@@ -80,7 +80,10 @@ impl WriteRecordBuilder {
     }
 
     /// Set the data of the record to write.
-    pub fn data(mut self, data: Bytes) -> Self {
+    pub fn data<B>(mut self, data: B) -> Self
+    where
+        B: Into<Body>,
+    {
         self.data = Some(data.into());
         self
     }


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

I've added new `each_n` and `each_s` query parameters to `Query Builder`.

### Related issues

reductstore/reductstore#465

### Does this PR introduce a breaking change?

No

### Other information:

### Other information:
