### PR TITLE
Use ring provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fix
+
+- Use ring provider, [PR-14](https://github.com/reductstore/reduct-rs/pull/14)
+
 ## [1.10.0] - 2024-06-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 http = "1.0.0"
-rustls = "0.23"
+rustls = { version = "0.23", features = ["ring"], default-features = false }
 chrono = { version = "0.4.38", features = ["serde"] }
 bytes = "1.4.0"
 futures = "0.3.17"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Rustls now uses the `aws-lc-rs' provider by default.  This breaks build scripts for the ARM32 platform, I've changed it back to `ring`.

### Related issues

(Add links to related issues)

No

(What changes might users need to make in their application due to this PR?)

### Other information:
