### PR TITLE
Unify string arguments in public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-31: `Bucket.update_record` and `Bucket.update_batch` to change labels of existing records, [PR-16](https://github.com/reductstore/reduct-rs/pull/16)
 
+### Changed
+
+- Unify string arguments in public API, [PR-17](https://github.com/reductstore/reduct-rs/pull/17)
+
 ## [1.10.1] - 2024-06-11
 
 ### Fixed

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -668,8 +668,8 @@ mod tests {
         let record1 = RecordBuilder::new()
             .timestamp_us(1000)
             .data(Bytes::from("Hey,"))
-            .add_label("test".into(), "1".into())
-            .content_type("text/plain".into())
+            .add_label("test", "1")
+            .content_type("text/plain")
             .build();
 
         let stream = futures_util::stream::iter(vec![Ok(Bytes::from("World"))]);
@@ -677,8 +677,8 @@ mod tests {
         let record2 = RecordBuilder::new()
             .timestamp_us(2000)
             .stream(Box::pin(stream))
-            .add_label("test".into(), "2".into())
-            .content_type("text/plain".into())
+            .add_label("test", "2")
+            .content_type("text/plain")
             .content_length(5)
             .build();
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -146,14 +146,20 @@ impl RecordBuilder {
     }
 
     /// Add a label to the record to write.
-    pub fn add_label(mut self, key: String, value: String) -> Self {
-        self.record.labels.insert(key, value);
+    pub fn add_label<Str>(mut self, key: Str, value: Str) -> Self
+    where
+        Str: Into<String>,
+    {
+        self.record.labels.insert(key.into(), value.into());
         self
     }
 
     /// Set the content type of the record to write.
-    pub fn content_type(mut self, content_type: String) -> Self {
-        self.record.content_type = content_type;
+    pub fn content_type<Str>(mut self, content_type: Str) -> Self
+    where
+        Str: Into<String>,
+    {
+        self.record.content_type = content_type.into();
         self
     }
 

--- a/src/record/query.rs
+++ b/src/record/query.rs
@@ -92,13 +92,16 @@ impl QueryBuilder {
     }
 
     /// Add a label to include in the query.
-    pub fn add_include(mut self, key: &str, value: &str) -> Self {
+    pub fn add_include<Str>(mut self, key: Str, value: Str) -> Self
+    where
+        Str: Into<String>,
+    {
         if let Some(mut labels) = self.include {
-            labels.insert(key.to_string(), value.to_string());
+            labels.insert(key.into(), value.into());
             self.include = Some(labels);
         } else {
             let mut labels = Labels::new();
-            labels.insert(key.to_string(), value.to_string());
+            labels.insert(key.into(), value.into());
             self.include = Some(labels);
         }
         self
@@ -111,13 +114,16 @@ impl QueryBuilder {
     }
 
     /// Add a label to exclude from the query.
-    pub fn add_exclude(mut self, key: &str, value: &str) -> Self {
+    pub fn add_exclude<Str>(mut self, key: Str, value: Str) -> Self
+    where
+        Str: Into<String>,
+    {
         if let Some(mut labels) = self.exclude {
-            labels.insert(key.to_string(), value.to_string());
+            labels.insert(key.into(), value.into());
             self.exclude = Some(labels);
         } else {
             let mut labels = Labels::new();
-            labels.insert(key.to_string(), value.to_string());
+            labels.insert(key.into(), value.into());
             self.exclude = Some(labels);
         }
         self

--- a/src/record/update_record.rs
+++ b/src/record/update_record.rs
@@ -56,8 +56,11 @@ impl UpdateRecordBuilder {
     }
 
     /// Add a label to the record to update.
-    pub fn update_label(mut self, key: &str, value: &str) -> Self {
-        self.labels.insert(key.to_string(), value.to_string());
+    pub fn update_label<Str>(mut self, key: Str, value: Str) -> Self
+    where
+        Str: Into<String>,
+    {
+        self.labels.insert(key.into(), value.into());
         self
     }
 
@@ -75,7 +78,7 @@ impl UpdateRecordBuilder {
                 return Err(ReductError::new(
                     ErrorCode::UnprocessableEntity,
                     "timestamp is required",
-                ))
+                ));
             }
         };
 

--- a/src/record/write_record.rs
+++ b/src/record/write_record.rs
@@ -61,14 +61,20 @@ impl WriteRecordBuilder {
     }
 
     /// Add a label to the record to write.
-    pub fn add_label(mut self, key: &str, value: &str) -> Self {
-        self.labels.insert(key.to_string(), value.to_string());
+    pub fn add_label<Str>(mut self, key: Str, value: Str) -> Self
+    where
+        Str: Into<String>,
+    {
+        self.labels.insert(key.into(), value.into());
         self
     }
 
     /// Set the content type of the record to write.
-    pub fn content_type(mut self, content_type: &str) -> Self {
-        self.content_type = content_type.to_string();
+    pub fn content_type<Str>(mut self, content_type: Str) -> Self
+    where
+        Str: Into<String>,
+    {
+        self.content_type = content_type.into();
         self
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Public methods receive Into<String> instead of &str or String. 

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
