### PR TITLE
RS-418: Use builder in Bucket.remove_record call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- RS-418: Methods `Bucket.remove_record`, `Bucket.remove_batch` and `Bucker.remove_query` for deleting records, [PR-19]https://github.com/reductstore/reduct-rs/pull/19)
+- RS-418: Methods `Bucket.remove_record`, `Bucket.remove_batch` and `Bucker.remove_query` for deleting records, [PR-19](https://github.com/reductstore/reduct-rs/pull/19)
+
+## Changed
+
+- RS-418: Use builder in `Bucket.remove_record` call, [PR-20](https://github.com/reductstore/reduct-rs/pull/20)
 
 ## [1.11.0] - 2024-08-19
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use bucket::Bucket;
 pub use client::ReductClient;
 pub use record::query::QueryBuilder;
 pub use record::read_record::ReadRecordBuilder;
+pub use record::remove_record::RemoveRecordBuilder;
 pub use record::write_batched_records::WriteBatchBuilder;
 pub use record::write_record::WriteRecordBuilder;
 pub use record::{Labels, Record, RecordBuilder, RecordStream};

--- a/src/record.rs
+++ b/src/record.rs
@@ -5,6 +5,7 @@
 
 pub mod query;
 pub mod read_record;
+pub mod remove_record;
 pub mod update_record;
 pub mod write_batched_records;
 pub mod write_record;

--- a/src/record/remove_record.rs
+++ b/src/record/remove_record.rs
@@ -1,0 +1,64 @@
+// Copyright 2024 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::http_client::HttpClient;
+use crate::record::from_system_time;
+use http::Method;
+use reduct_base::error::ReductError;
+use std::sync::Arc;
+
+/// Builder for a remove record request.
+pub struct RemoveRecordBuilder {
+    bucket: String,
+    entry: String,
+    timestamp: Option<u64>,
+    client: Arc<HttpClient>,
+}
+
+impl RemoveRecordBuilder {
+    pub(crate) fn new(bucket: String, entry: String, client: Arc<HttpClient>) -> Self {
+        Self {
+            bucket,
+            entry,
+            timestamp: None,
+            client,
+        }
+    }
+
+    /// Set the timestamp of the record to remove as a unix timestamp in microseconds.
+    pub fn timestamp_us(mut self, timestamp: u64) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    /// Set the timestamp of the record to remove.
+    pub fn timestamp(mut self, timestamp: std::time::SystemTime) -> Self {
+        self.timestamp = Some(from_system_time(timestamp));
+        self
+    }
+
+    /// Send the remove record request.
+    ///
+    /// # Returns
+    ///
+    /// Returns an error if the record could not be removed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the timestamp is not set.
+    pub async fn send(self) -> Result<(), ReductError> {
+        let request = self.client.request(
+            Method::DELETE,
+            &format!(
+                "/b/{}/{}?ts={}",
+                self.bucket,
+                self.entry,
+                self.timestamp.expect("timestamp is required")
+            ),
+        );
+        self.client.send_request(request).await?;
+        Ok(())
+    }
+}

--- a/src/record/update_record.rs
+++ b/src/record/update_record.rs
@@ -13,7 +13,7 @@ use reduct_base::error::{ErrorCode, ReductError};
 use std::sync::Arc;
 use std::time::SystemTime;
 
-/// Builder for a write record request.
+/// Builder for an update record request.
 pub struct UpdateRecordBuilder {
     bucket: String,
     entry: String,


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Refactoring

### What was changed?

Use a builder pattern in Bucket.record_record to set the timestmap more flexible:

```rust
bucket.remove_record("entry").timestamp_us(1000).send.await;
```

### Related issues

reductstore/reductstore#560

### Does this PR introduce a breaking change?

Yes, but inside the development branch.

### Other information:
