### PR TITLE
RS-388: Add Bucket::rename_entry method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RS-418: Methods `Bucket.remove_record`, `Bucket.remove_batch` and `Bucker.remove_query` for deleting records, [PR-19](https://github.com/reductstore/reduct-rs/pull/19)
+- RS-388: Add `Bucket.rename_entry` method, [PR-24](https://github.com/reductstore/reduct-rs/pull/24)
 
 ## Changed
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The `Bucket::rename_entry` method was added.


### Related issues

https://github.com/reductstore/reductstore/pull/596

### Does this PR introduce a breaking change?

No

### Other information:
