### PR TITLE
RS-419: Add Bucket.rename method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-418: Methods `Bucket.remove_record`, `Bucket.remove_batch` and `Bucker.remove_query` for deleting records, [PR-19](https://github.com/reductstore/reduct-rs/pull/19)
 - RS-388: Add `Bucket.rename_entry` method, [PR-24](https://github.com/reductstore/reduct-rs/pull/24)
+- RS-419: Add `Bucket.rename` method. [PR-25](https://github.com/reductstore/reduct-rs/pull/25)
 
 ## Changed
 

--- a/src/record/write_batched_records.rs
+++ b/src/record/write_batched_records.rs
@@ -11,7 +11,6 @@ use reqwest::header::{HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
 use reqwest::{Body, Method};
 use std::collections::{BTreeMap, VecDeque};
 
-use crate::record::from_system_time;
 use reduct_base::error::{ErrorCode, IntEnum, ReductError};
 use std::sync::Arc;
 use std::time::SystemTime;


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The `Bucket.rename` method was added.

### Related issues

https://github.com/reductstore/reductstore/pull/597

### Does this PR introduce a breaking change?

No

### Other information:
