### PR TITLE
RS-550: Add when condition to replication settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         reductstore_version: [ "main", "latest" ]
         include:
           - reductstore_version: main
-            features: "default test-api-113"
+            features: "default test-api-114"
           - reductstore_version: latest
             features: "default"
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- RS-550: Add support for when condition on replication settings, [PR-29](https://github.com/reductstore/reduct-rs/pull/29)
+
 ## [1.13.0] - 2024-12-04
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reduct-rs"
 
-version = "1.13.0"
+version = "1.14.0"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.80.0"
@@ -23,7 +23,7 @@ test-api-113 = []   # Test API 1.13
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = "1.13.0"
+reduct-base = { git = "https://github.com/reductstore/reductstore.git", branch = "main" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database"]
 
 [features]
 default = []
-test-api-113 = []   # Test API 1.13
+test-api-114 = []   # Test API 1.13
 
 
 [lib]

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -4,8 +4,7 @@
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use futures_util::StreamExt;
-use reduct_rs::{ReductClient, ReductError};
-use serde_json::json;
+use reduct_rs::{condition, ReductClient, ReductError};
 use std::str::from_utf8;
 
 #[tokio::main]
@@ -32,7 +31,7 @@ async fn main() -> Result<(), ReductError> {
 
     let query = bucket
         .query("entry-1")
-        .when(json!({"&planet": {"$eq": "Mars"}}))
+        .when(condition!({"&planet": {"$eq": "Mars"}}))
         .send()
         .await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -577,6 +577,7 @@ pub(crate) mod tests {
 
         #[rstest]
         #[tokio::test]
+        #[cfg_attr(not(feature = "test-api-114"), ignore)]
         async fn test_get_replication(
             #[future] client: ReductClient,
             settings: ReplicationSettings,

--- a/src/client.rs
+++ b/src/client.rs
@@ -552,6 +552,7 @@ pub(crate) mod tests {
 
         #[rstest]
         #[tokio::test]
+        #[cfg_attr(not(feature = "test-api-114"), ignore)]
         async fn test_create_replication(
             #[future] client: ReductClient,
             settings: ReplicationSettings,
@@ -564,8 +565,6 @@ pub(crate) mod tests {
                 .dst_host(settings.dst_host.as_str())
                 .dst_token(settings.dst_token.as_str())
                 .entries(settings.entries.clone())
-                .include(settings.include.clone())
-                .exclude(settings.exclude.clone())
                 .each_s(settings.each_s.unwrap())
                 .each_n(settings.each_n.unwrap())
                 .when(settings.when.unwrap())
@@ -612,6 +611,7 @@ pub(crate) mod tests {
 
         #[rstest]
         #[tokio::test]
+        #[cfg_attr(not(feature = "test-api-114"), ignore)]
         async fn test_update_replication(
             #[future] client: ReductClient,
             settings: ReplicationSettings,

--- a/src/client.rs
+++ b/src/client.rs
@@ -539,6 +539,7 @@ pub(crate) mod tests {
 
     mod replication_api {
         use super::*;
+        use crate::condition;
         use reduct_base::msg::diagnostics::Diagnostics;
         use reduct_base::msg::replication_api::ReplicationSettings;
 
@@ -567,6 +568,7 @@ pub(crate) mod tests {
                 .exclude(settings.exclude.clone())
                 .each_s(settings.each_s.unwrap())
                 .each_n(settings.each_n.unwrap())
+                .when(settings.when.unwrap())
                 .send()
                 .await
                 .unwrap();
@@ -662,6 +664,7 @@ pub(crate) mod tests {
                 exclude: Labels::default(),
                 each_s: Some(1.0),
                 each_n: Some(1),
+                when: Some(condition!({"$eq": ["&label", 1]})),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,5 @@ pub use reduct_base::msg::replication_api::{
 };
 pub use reduct_base::msg::server_api::{BucketInfoList, Defaults, ServerInfo};
 pub use reduct_base::msg::token_api::{Permissions, Token};
+pub use serde_json::json as condition;
+pub use serde_json::Value as JsonValue;

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -33,6 +33,7 @@ impl ReplicationBuilder {
                 exclude: Default::default(),
                 each_s: None,
                 each_n: None,
+                when: None,
             },
             http_client,
         }
@@ -92,7 +93,8 @@ impl ReplicationBuilder {
     /// # Arguments
     ///
     /// * `include` - Replication include. If empty, all labels will be replicated.
-    ///         If a few labels are specified, records must have all of them to be replicated.
+    ///
+    #[deprecated(since = "1.14.0", note = "Use the `when` method instead.")]
     pub fn include(mut self, include: Labels) -> Self {
         self.settings.include = include;
         self
@@ -104,6 +106,7 @@ impl ReplicationBuilder {
     ///
     /// * `exclude` - Replication exclude. If empty, no labels will be excluded.
     ///        If a few labels are specified, records must have none of them to be replicated.
+    #[deprecated(since = "1.14.0", note = "Use the `when` method instead.")]
     pub fn exclude(mut self, exclude: Labels) -> Self {
         self.settings.exclude = exclude;
         self
@@ -130,6 +133,16 @@ impl ReplicationBuilder {
     /// * `each_n` - Replicate every Nth record.
     pub fn each_n(mut self, each_n: u64) -> Self {
         self.settings.each_n = Some(each_n);
+        self
+    }
+
+    /// Set the replication conditional query.
+    ///
+    /// # Arguments
+    ///
+    /// * `when` - Conditional query.
+    pub fn when(mut self, when: serde_json::Value) -> Self {
+        self.settings.when = Some(when);
         self
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR adds the `ReplicationBuilder.when` method to pass the conditional query to the replication settings.

### Related issues

https://github.com/reductstore/reductstore/pull/687

### Does this PR introduce a breaking change?

No

### Other information:
