### PR TITLE
RS-628: Support ext parameter to QueryBuilder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         reductstore_version: [ "main", "latest" ]
         include:
           - reductstore_version: main
-            features: "default,test-api-114"
+            features: "default,test-api-115"
           - reductstore_version: latest
             features: "default"
     needs:
@@ -50,6 +50,7 @@ jobs:
       - name: Run Database
         run: docker run --network=host -v ${PWD}/misc:/misc
           --env RS_API_TOKEN=TOKEN
+          --env RS_EXT_PATH=/tmp
           --env RS_LICENSE_PATH=/misc/lic.key -d reduct/store:${{ matrix.reductstore_version }}
       - name: Run Client SDK tests
         run: RS_API_TOKEN=TOKEN cargo test --features ${{ matrix.features }} -- --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- RS-628: Support `ext` parameter to `QueryBuilder`, [PR-32](https://github.com/reductstore/reduct-rs/pull/32)
+
 ## [1.14.0] - 2025-02-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ categories = ["database"]
 
 [features]
 default = []
-test-api-114 = []   # Test API 1.13
+test-api-115 = []   # Test API 1.15
 
 
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = "1.14.0"
+reduct-base = { git = "https://github.com/reductstore/reductstore.git"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ database for unstructured data.
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.14](https://www.reduct.store/docs/http-api)
+* Supports the [ReductStore HTTP API v1.15](https://www.reduct.store/docs/http-api)
 * Built on top of [reqwest](https://github.com/seanmonstar/reqwest)
 * Asynchronous API
 

--- a/src/bucket/read.rs
+++ b/src/bucket/read.rs
@@ -67,7 +67,7 @@ impl Bucket {
 #[cfg(test)]
 mod tests {
     use crate::bucket::tests::bucket;
-    use crate::Bucket;
+    use crate::{ext, Bucket};
     use bytes::Bytes;
     use chrono::Duration;
     use futures::pin_mut;
@@ -271,5 +271,25 @@ mod tests {
         let query = query.unwrap();
         pin_mut!(query);
         assert!(query.next().await.unwrap().is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[cfg_attr(not(feature = "test-api-115"), ignore)]
+    async fn test_query_ext(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        let query = bucket
+            .query("entry-1")
+            .ext(ext!({
+                "test": { "param": 1}
+            }))
+            .send()
+            .await;
+
+        assert!(query
+            .err()
+            .unwrap()
+            .message()
+            .starts_with("Unknown extension"))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -552,7 +552,6 @@ pub(crate) mod tests {
 
         #[rstest]
         #[tokio::test]
-        #[cfg_attr(not(feature = "test-api-114"), ignore)]
         async fn test_create_replication(
             #[future] client: ReductClient,
             settings: ReplicationSettings,
@@ -577,7 +576,6 @@ pub(crate) mod tests {
 
         #[rstest]
         #[tokio::test]
-        #[cfg_attr(not(feature = "test-api-114"), ignore)]
         async fn test_get_replication(
             #[future] client: ReductClient,
             settings: ReplicationSettings,
@@ -612,7 +610,6 @@ pub(crate) mod tests {
 
         #[rstest]
         #[tokio::test]
-        #[cfg_attr(not(feature = "test-api-114"), ignore)]
         async fn test_update_replication(
             #[future] client: ReductClient,
             settings: ReplicationSettings,

--- a/src/client.rs
+++ b/src/client.rs
@@ -592,7 +592,7 @@ pub(crate) mod tests {
                 replication.info,
                 ReplicationInfo {
                     name: "test-replication".to_string(),
-                    is_active: false,
+                    is_active: true,
                     is_provisioned: false,
                     pending_records: 0,
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,5 @@ pub use reduct_base::msg::replication_api::{
 pub use reduct_base::msg::server_api::{BucketInfoList, Defaults, ServerInfo};
 pub use reduct_base::msg::token_api::{Permissions, Token};
 pub use serde_json::json as condition;
+pub use serde_json::json as ext; // for readability
 pub use serde_json::Value as JsonValue;

--- a/src/record/query.rs
+++ b/src/record/query.rs
@@ -79,6 +79,13 @@ impl QueryBuilder {
         self
     }
 
+    /// Set extension parameters for the query.
+    /// This is a JSON object that will be passed to extensions on the server side.
+    pub fn ext(mut self, ext: Value) -> Self {
+        self.query.ext = Some(ext);
+        self
+    }
+
     /// Set the labels to include in the query.
     #[deprecated(
         since = "1.13.0",
@@ -183,37 +190,36 @@ impl QueryBuilder {
     pub async fn send(
         mut self,
     ) -> Result<impl Stream<Item = Result<Record, ReductError>>, ReductError> {
-        let response = match self.query.when {
-            Some(_) => {
-                self.query.query_type = QueryType::Query;
-                self.client
-                    .send_and_receive_json::<QueryEntry, QueryInfo>(
-                        Method::POST,
-                        &format!("/b/{}/{}/q", self.bucket, self.entry),
-                        Some(self.query.clone()),
-                    )
-                    .await?
+        let response = if self.query.when.is_some() || self.query.ttl.is_some() {
+            // use new POST API for new features
+            self.query.query_type = QueryType::Query;
+            self.client
+                .send_and_receive_json::<QueryEntry, QueryInfo>(
+                    Method::POST,
+                    &format!("/b/{}/{}/q", self.bucket, self.entry),
+                    Some(self.query.clone()),
+                )
+                .await?
+        } else {
+            // TODO: must be removed in the future
+            let mut url = build_base_url(self.query.clone(), &self.bucket, &self.entry);
+
+            if let Some(limit) = self.query.limit.as_ref() {
+                url.push_str(&format!("&limit={}", limit));
             }
-            None => {
-                let mut url = build_base_url(self.query.clone(), &self.bucket, &self.entry);
 
-                if let Some(limit) = self.query.limit.as_ref() {
-                    url.push_str(&format!("&limit={}", limit));
-                }
-
-                // control parameters
-                if self.query.continuous.unwrap_or(false) {
-                    url.push_str("&continuous=true");
-                }
-
-                if let Some(ttl) = self.query.ttl.as_ref() {
-                    url.push_str(&format!("&ttl={}", ttl));
-                }
-
-                self.client
-                    .send_and_receive_json::<(), QueryInfo>(Method::GET, &url, None)
-                    .await?
+            // control parameters
+            if self.query.continuous.unwrap_or(false) {
+                url.push_str("&continuous=true");
             }
+
+            if let Some(ttl) = self.query.ttl.as_ref() {
+                url.push_str(&format!("&ttl={}", ttl));
+            }
+
+            self.client
+                .send_and_receive_json::<(), QueryInfo>(Method::GET, &url, None)
+                .await?
         };
 
         let head_only = self.query.only_metadata.as_ref().unwrap_or(&false).clone();

--- a/src/record/query.rs
+++ b/src/record/query.rs
@@ -190,7 +190,7 @@ impl QueryBuilder {
     pub async fn send(
         mut self,
     ) -> Result<impl Stream<Item = Result<Record, ReductError>>, ReductError> {
-        let response = if self.query.when.is_some() || self.query.ttl.is_some() {
+        let response = if self.query.when.is_some() || self.query.ext.is_some() {
             // use new POST API for new features
             self.query.query_type = QueryType::Query;
             self.client


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR adds the ext parameter to the QuertBuilder method to process data with extensions:

```rust
        let bucket: Bucket = bucket.await;
        let query = bucket
            .query("entry-1")
            .ext(ext!({
                "test": { "param": 1}
            }))
            .send()
            .await;
```

### Related issues

[(Add links to related issues)](https://github.com/reductstore/reductstore/pull/762)

### Does this PR introduce a breaking change?

No

### Other information:
