### PR TITLE
Fix publishing cargo package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   REGISTRY_IMAGE: reduct/store
-  MINIMAL_RUST_VERSION: 1.80.0
+  MINIMAL_RUST_VERSION: 1.85.0
 
 jobs:
   rust_fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,20 @@ jobs:
       - name: Run Client SDK tests
         run: cargo run --example ${{matrix.example}}
 
+  dry_publish:
+    runs-on: ubuntu-latest
+    name: Dry run publish
+    needs:
+      - rust_fmt
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.MINIMAL_RUST_VERSION }}
+      - name: Dry run publish reduct-rs
+        run: cargo publish --dry-run -p reduct-rs
+
   check_tag:
     runs-on: ubuntu-latest
     name: Check tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Minimal Rust version is 1.85
+
 ## [1.15.0] - 2025-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Minimal Rust version is 1.85
+- Minimal Rust version is 1.85, [PR-36](https://github.com/reductstore/reduct-rs/pull/36)
 
 ## [1.15.0] - 2025-05-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "reduct-rs"
 version = "1.15.0"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reduct-rs"
 
-version = "1.15.0"
+version = "1.15.1"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.85.0"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The package could not be published for Rust 1.80. The PR increases the minimum version to 1.85 and adds a task to test the publication process.

### Related issues

(Add links to related issues)

### Does this PR introduce a breaking change?

(What changes might users need to make in their application due to this PR?)

### Other information:
