### PR TITLE
Fix parsing url with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix parsing url with prefix, [PR-37](https://github.com/reductstore/reduct-rs/pull/37)
+
 ## [1.15.1] - 2025-05-27
 
 ### Changed

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,7 +31,7 @@ pub struct ReductClientBuilder {
 
 pub type Result<T> = std::result::Result<T, ReductError>;
 
-static API_BASE: &str = "api/v1";
+pub(super) static API_BASE: &str = "api/v1";
 
 impl ReductClientBuilder {
     fn new() -> Self {

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -3,7 +3,7 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::client::Result;
+use crate::client::{Result, API_BASE};
 use reduct_base::error::{ErrorCode, IntEnum, ReductError};
 use reqwest::header::HeaderValue;
 use reqwest::{Method, RequestBuilder, Response, Url};
@@ -25,9 +25,7 @@ impl HttpClient {
     }
 
     pub fn url(&self) -> &str {
-        const API_BASE: &str = "/api/v1";
         &self.base_url.as_str()[..self.base_url.as_str().len() - API_BASE.len()]
-        // Remove API_BASE
     }
 
     pub fn api_token(&self) -> &str {

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -25,7 +25,8 @@ impl HttpClient {
     }
 
     pub fn url(&self) -> &str {
-        &self.base_url.as_str()[..self.base_url.as_str().len() - 6] // Remove /api/v1
+        const API_BASE: &str = "/api/v1";
+        &self.base_url.as_str()[..self.base_url.as_str().len() - API_BASE.len()] // Remove API_BASE
     }
 
     pub fn api_token(&self) -> &str {

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -25,7 +25,7 @@ impl HttpClient {
     }
 
     pub fn url(&self) -> &str {
-        &self.base_url.as_str()[..self.base_url.as_str().len() - 7] // Remove /api/v1
+        &self.base_url.as_str()[..self.base_url.as_str().len() - 6] // Remove /api/v1
     }
 
     pub fn api_token(&self) -> &str {

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -26,7 +26,8 @@ impl HttpClient {
 
     pub fn url(&self) -> &str {
         const API_BASE: &str = "/api/v1";
-        &self.base_url.as_str()[..self.base_url.as_str().len() - API_BASE.len()] // Remove API_BASE
+        &self.base_url.as_str()[..self.base_url.as_str().len() - API_BASE.len()]
+        // Remove API_BASE
     }
 
     pub fn api_token(&self) -> &str {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR fixes the way the server URL is parsed when it has a prefix.

### Related issues

https://github.com/reductstore/reduct-cli/issues/111

### Does this PR introduce a breaking change?

No

### Other information:
