### PR TITLE
Remove deprecated exclude\include parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Removed
 
 - Remove legacy code in remove query, [PR-35](https://github.com/reductstore/reduct-rs/pull/35)
+- Deprecated `include\exclude` parameters in `QueryBuilder`, `RemoveQueryBuilder` and `ReplicationSettings`, [PR-41](https://github.com/reductstore/reduct-rs/pull/41)
 
 ## [1.15.2] - 2025-06-11
 

--- a/src/bucket/read.rs
+++ b/src/bucket/read.rs
@@ -275,7 +275,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg_attr(not(feature = "test-api-115"), ignore)]
     async fn test_query_ext(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         let query = bucket

--- a/src/record/query.rs
+++ b/src/record/query.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 ReductStore
+// Copyright 2023-2025 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -15,7 +15,6 @@ use futures_util::{pin_mut, StreamExt};
 use reduct_base::batch::{parse_batched_header, sort_headers_by_time, RecordHeader};
 use reduct_base::error::ReductError;
 use reduct_base::msg::entry_api::{QueryEntry, QueryInfo, QueryType, RemoveQueryInfo};
-use reduct_base::Labels;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Method;
 use serde_json::Value;
@@ -85,67 +84,7 @@ impl QueryBuilder {
         self.query.ext = Some(ext);
         self
     }
-
-    /// Set the labels to include in the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to set the labels to include in the query."
-    )]
-    pub fn include(mut self, labels: Labels) -> Self {
-        self.query.include = Some(labels);
-        self
-    }
-
-    /// Add a label to include in the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to set the labels to exclude from the query."
-    )]
-    pub fn add_include<Str>(mut self, key: Str, value: Str) -> Self
-    where
-        Str: Into<String>,
-    {
-        if let Some(mut labels) = self.query.include {
-            labels.insert(key.into(), value.into());
-            self.query.include = Some(labels);
-        } else {
-            let mut labels = Labels::new();
-            labels.insert(key.into(), value.into());
-            self.query.include = Some(labels);
-        }
-        self
-    }
-
-    /// Set the labels to exclude from the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to set the labels to exclude from the query. It will be remove in v1.16.0."
-    )]
-    pub fn exclude(mut self, labels: Labels) -> Self {
-        self.query.exclude = Some(labels);
-        self
-    }
-
-    /// Add a label to exclude from the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to add a label to exclude from the query. It will be remove in v1.16.0."
-    )]
-    pub fn add_exclude<Str>(mut self, key: Str, value: Str) -> Self
-    where
-        Str: Into<String>,
-    {
-        if let Some(mut labels) = self.query.exclude {
-            labels.insert(key.into(), value.into());
-            self.query.exclude = Some(labels);
-        } else {
-            let mut labels = Labels::new();
-            labels.insert(key.into(), value.into());
-            self.query.exclude = Some(labels);
-        }
-        self
-    }
-
+    
     /// Set S, to return a record every S seconds.
     /// default: return all records
     #[deprecated(
@@ -309,66 +248,6 @@ impl RemoveQueryBuilder {
     /// default: false
     pub fn strict(mut self, strict: bool) -> Self {
         self.query.strict = Some(strict);
-        self
-    }
-
-    /// Set the labels to include in the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to set the labels to exclude from the query. It will be remove in v1.16.0."
-    )]
-    pub fn include(mut self, labels: Labels) -> Self {
-        self.query.include = Some(labels);
-        self
-    }
-
-    /// Add a label to include in the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to set the labels to exclude from the query. It will be remove in v1.16.0."
-    )]
-    pub fn add_include<Str>(mut self, key: Str, value: Str) -> Self
-    where
-        Str: Into<String>,
-    {
-        if let Some(mut labels) = self.query.include {
-            labels.insert(key.into(), value.into());
-            self.query.include = Some(labels);
-        } else {
-            let mut labels = Labels::new();
-            labels.insert(key.into(), value.into());
-            self.query.include = Some(labels);
-        }
-        self
-    }
-
-    /// Set the labels to exclude from the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to set the labels to exclude from the query. It will be remove in v1.16.0."
-    )]
-    pub fn exclude(mut self, labels: Labels) -> Self {
-        self.query.exclude = Some(labels);
-        self
-    }
-
-    /// Add a label to exclude from the query.
-    #[deprecated(
-        since = "1.13.0",
-        note = "Use the `when` method to set the labels to exclude from the query. It will be remove in v1.16.0."
-    )]
-    pub fn add_exclude<Str>(mut self, key: Str, value: Str) -> Self
-    where
-        Str: Into<String>,
-    {
-        if let Some(mut labels) = self.query.exclude {
-            labels.insert(key.into(), value.into());
-            self.query.exclude = Some(labels);
-        } else {
-            let mut labels = Labels::new();
-            labels.insert(key.into(), value.into());
-            self.query.exclude = Some(labels);
-        }
         self
     }
 

--- a/src/record/query.rs
+++ b/src/record/query.rs
@@ -84,7 +84,7 @@ impl QueryBuilder {
         self.query.ext = Some(ext);
         self
     }
-    
+
     /// Set S, to return a record every S seconds.
     /// default: return all records
     #[deprecated(

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -86,7 +86,7 @@ impl ReplicationBuilder {
         self.settings.entries = entries;
         self
     }
-    
+
     /// Set the replication each_s setting.
     ///
     /// Replicate a record every S seconds if set.

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 ReductStore
+// Copyright 2024-2025 ReductStore
 // This Source Code Form is subject to the terms of the Mozilla Public
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,7 +7,6 @@ use crate::client::Result;
 use crate::http_client::HttpClient;
 
 use reduct_base::msg::replication_api::ReplicationSettings;
-use reduct_base::Labels;
 use reqwest::Method;
 use std::sync::Arc;
 
@@ -87,37 +86,7 @@ impl ReplicationBuilder {
         self.settings.entries = entries;
         self
     }
-
-    /// Set the replication include.
-    ///
-    /// # Arguments
-    ///
-    /// * `include` - Replication include. If empty, all labels will be replicated.
-    ///
-    #[deprecated(
-        since = "1.14.0",
-        note = "Use the `when` method instead. It will be removed in v1.18.0."
-    )]
-    pub fn include(mut self, include: Labels) -> Self {
-        self.settings.include = include;
-        self
-    }
-
-    /// Set the replication exclude.
-    ///
-    /// # Arguments
-    ///
-    /// * `exclude` - Replication exclude. If empty, no labels will be excluded.
-    ///        If a few labels are specified, records must have none of them to be replicated.
-    #[deprecated(
-        since = "1.14.0",
-        note = "Use the `when` method instead. It will be removed in v1.18.0."
-    )]
-    pub fn exclude(mut self, exclude: Labels) -> Self {
-        self.settings.exclude = exclude;
-        self
-    }
-
+    
     /// Set the replication each_s setting.
     ///
     /// Replicate a record every S seconds if set.


### PR DESCRIPTION
Closes #40 

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Removal

### What was changed?


- **Removed deprecated `exclude` and `include` parameters:**  
  All usage of the deprecated `exclude` and `include` parameters has been removed from the codebase. These parameters are no longer supported and their presence has been fully eliminated from public APIs and internal logic.
- **Code and documentation cleanup:**  
  Any references, documentation comments, or code paths that mentioned or handled `exclude`/`include` have been updated or deleted to reflect their removal.

### Related issues

#40 , https://github.com/reductstore/reductstore/issues/873

### Does this PR introduce a breaking change?

Yes

### Other information:
