### PR TITLE
Fix error handling for batched records in QueryBuilder.send()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fix error handling for batched records in `QueryBuilder.send()`, [PR-44](https://github.com/reductstore/reduct-rs/pull/44)
+
 ## [1.16.0] - 2025-07-31
 
 ### Breaking Changes


### PR DESCRIPTION
Closes #43

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The PR fixes unwrapping errors from the incoming stream when the SDK parses the batched record in a query. 
Now a client can handle timeout and communication errors that happen in the middle of data download.

### Related issues

#43 

### Does this PR introduce a breaking change?

No

### Other information:
