### PR TITLE
Implement Bucket.create_query_link method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         reductstore_version: [ "main", "latest" ]
         include:
           - reductstore_version: main
-            features: "default,test-api-116"
+            features: "default,test-api-117"
           - reductstore_version: latest
             features: "default"
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
   dry_publish:
     runs-on: ubuntu-latest
     name: Dry run publish
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - rust_fmt
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement `Bucket.create_query_link` method, [PR-45](https://github.com/reductstore/reduct-rs/pull/45)
+
 ## [1.16.1] - 2025-08-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reduct-rs"
 
-version = "1.16.1"
+version = "1.17.0"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.85.0"
@@ -16,14 +16,14 @@ categories = ["database"]
 
 [features]
 default = []
-test-api-116 = []   # Test API 1.16
+test-api-117 = []   # Test API 1.16
 
 
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = "1.16.0"
+reduct-base = { git="https://github.com/reductstore/reductstore", branch="main"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test-api-117 = []   # Test API 1.16
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = { git="https://github.com/reductstore/reductstore", branch="main"}
+reduct-base = { git="https://github.com/reductstore/reductstore", branch="main", version = "1.17.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -3,6 +3,7 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod link;
 mod read;
 mod remove;
 mod update;

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -1,0 +1,150 @@
+// Copyright 2025 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::http_client::HttpClient;
+use crate::Bucket;
+use chrono::{DateTime, Utc};
+use http::Method;
+use reduct_base::error::ReductError;
+use reduct_base::msg::entry_api::QueryEntry;
+use reduct_base::msg::query_link_api::{QueryLinkCreateRequest, QueryLinkCreateResponse};
+use std::sync::Arc;
+
+pub struct CreateQueryLinkBuilder {
+    request: QueryLinkCreateRequest,
+    http_client: Arc<HttpClient>,
+}
+
+impl CreateQueryLinkBuilder {
+    pub(crate) fn new(bucket: String, entry: String, http_client: Arc<HttpClient>) -> Self {
+        Self {
+            request: QueryLinkCreateRequest {
+                bucket,
+                entry,
+                expire_at: Utc::now() + chrono::Duration::hours(24),
+                ..Default::default()
+            },
+            http_client,
+        }
+    }
+
+    /// Set the expiration time for the query link.
+    pub fn expire_at(mut self, expire_at: DateTime<Utc>) -> Self {
+        self.request.expire_at = expire_at;
+        self
+    }
+
+    /// Set the record index for the query link.
+    pub fn index(mut self, index: u64) -> Self {
+        self.request.index = Some(index);
+        self
+    }
+
+    /// Set the query to share.
+    pub fn query(mut self, query: QueryEntry) -> Self {
+        self.request.query = query;
+        self
+    }
+
+    /// Send the create query link request.
+    pub async fn send(self) -> Result<String, ReductError> {
+        let response: QueryLinkCreateResponse = self
+            .http_client
+            .send_and_receive_json(Method::POST, "/links", Some(self.request))
+            .await?;
+        Ok(response.link)
+    }
+}
+
+impl Bucket {
+    /// Create a query link for sharing.
+    ///
+    /// # Arguments
+    ///
+    /// * `entry` - The entry to create the query link for.
+    ///
+    /// # Returns
+    ///
+    /// Returns a builder for creating a query link.
+    pub fn create_query_link(&self, entry: &str) -> CreateQueryLinkBuilder {
+        CreateQueryLinkBuilder::new(
+            self.name.clone(),
+            entry.to_string(),
+            self.http_client.clone(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bucket::tests::bucket;
+    use crate::Bucket;
+    use reduct_base::msg::entry_api::QueryEntry;
+    use rstest::rstest;
+
+    #[cfg(feature = "test-api-117")]
+    #[rstest]
+    #[tokio::test]
+    async fn test_link_creation(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        let link = bucket
+            .create_query_link("entry-1")
+            .expire_at(chrono::Utc::now() + chrono::Duration::hours(1))
+            .send()
+            .await
+            .unwrap();
+
+        let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
+        assert_eq!(body, "Hey entry-1!");
+    }
+
+    #[cfg(feature = "test-api-117")]
+    #[rstest]
+    #[tokio::test]
+    async fn test_link_creation_with_query(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        let link = bucket
+            .create_query_link("entry-1")
+            .query(QueryEntry {
+                start: Some(0),
+                ..Default::default()
+            })
+            .send()
+            .await
+            .unwrap();
+        let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
+        assert_eq!(body, "Hey entry-1!");
+    }
+
+    #[cfg(feature = "test-api-117")]
+    #[rstest]
+    #[tokio::test]
+    async fn test_link_creation_with_index(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        let link = bucket
+            .create_query_link("entry-1")
+            .index(1)
+            .send()
+            .await
+            .unwrap();
+        let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
+        assert_eq!(body, r#"{"detail": "Record number out of range"}"#)
+    }
+
+    #[cfg(feature = "test-api-117")]
+    #[rstest]
+    #[tokio::test]
+    async fn test_link_creation_expired(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        let link = bucket
+            .create_query_link("entry-1")
+            .expire_at(chrono::Utc::now() - chrono::Duration::hours(1))
+            .send()
+            .await
+            .unwrap();
+        let response = reqwest::get(&link).await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    }
+}

--- a/src/record.rs
+++ b/src/record.rs
@@ -44,7 +44,7 @@ pub struct Record {
     timestamp: u64,
     labels: Labels,
     content_type: String,
-    content_length: usize,
+    content_length: u64,
     data: Option<RecordStream>,
 }
 
@@ -79,7 +79,7 @@ impl Record {
 
     /// Content length of the record
     pub fn content_length(&self) -> usize {
-        self.content_length
+        self.content_length as usize
     }
 
     /// Content of the record
@@ -170,7 +170,7 @@ impl RecordBuilder {
     ///
     /// Note: use this with stream data
     pub fn content_length(mut self, content_length: usize) -> Self {
-        self.record.content_length = content_length;
+        self.record.content_length = content_length as u64;
         self
     }
 
@@ -182,7 +182,7 @@ impl RecordBuilder {
         D: Into<Bytes>,
     {
         let bytes = data.into();
-        self.record.content_length = bytes.len();
+        self.record.content_length = bytes.len() as u64;
         self.record.data = Some(Box::pin(futures::stream::once(async move { Ok(bytes) })));
         self
     }

--- a/src/record/query.rs
+++ b/src/record/query.rs
@@ -353,13 +353,13 @@ async fn parse_batched_records(
                     let mut data = rest_data.clone();
                     while let Ok(bytes) = rx.recv().await {
                         data.extend_from_slice(&unwrap_byte(bytes)?);
-                        if data.len() >= content_length {
+                        if data.len() >= content_length  as usize {
                             break;
                         }
                     }
 
-                    rest_data = data.split_off(content_length);
-                    data.truncate(content_length);
+                    rest_data = data.split_off(content_length as usize);
+                    data.truncate(content_length as usize);
 
                     Some(Box::pin(stream! {
                         yield Ok(data.into());

--- a/src/record/read_record.rs
+++ b/src/record/read_record.rs
@@ -109,7 +109,7 @@ impl ReadRecordBuilder {
                 .unwrap()
                 .to_str()
                 .unwrap()
-                .parse::<usize>()
+                .parse::<u64>()
                 .unwrap(),
             data: if self.head_only {
                 None


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The PR introduces the 'Bucket.create_query_link` method, which is used to create query links for sharing particular data without permissions. 

### Related issues

https://github.com/reductstore/reductstore/pull/938

### Does this PR introduce a breaking change?

No

### Other information:
