### PR TITLE
Diable broken replication settings tests for v1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement `Bucket.create_query_link` method, [PR-45](https://github.com/reductstore/reduct-rs/pull/45)
 
+### Fixed
+
+- Diable broken replication settings tests for v1.16, [PR-47](https://github.com/reductstore/reduct-rs/pull/47)
+
 ## [1.16.1] - 2025-08-26
 
 ### Fixed

--- a/src/client.rs
+++ b/src/client.rs
@@ -597,6 +597,7 @@ pub(crate) mod tests {
             assert_eq!(replications.len(), 1);
         }
 
+        #[cfg(feature = "test-api-117")]
         #[rstest]
         #[tokio::test]
         async fn test_get_replication(
@@ -631,6 +632,7 @@ pub(crate) mod tests {
             assert_eq!(replication.diagnostics, Diagnostics::default());
         }
 
+        #[cfg(feature = "test-api-117")]
         #[rstest]
         #[tokio::test]
         async fn test_update_replication(


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The Replication API v1.17 has breaking changes. I've disable some tests for v1.16

### Related issues

https://github.com/reductstore/reductstore/pull/983

### Does this PR introduce a breaking change?

No

### Other information:
