### PR TITLE
Add base_url to Bucket.create_query_link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- Add `base_url` to `Bucket.create_query_link`, [PR-48](https://github.com/reductstore/reduct-rs/pull/51)
+
 ## [1.17.0] - 2025-10-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test-api-117 = []   # Test API 1.16
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = "1.17.0"
+reduct-base = "1.17.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -16,6 +16,7 @@ pub struct CreateQueryLinkBuilder {
     request: QueryLinkCreateRequest,
     file_name: Option<String>,
     http_client: Arc<HttpClient>,
+    base_url: Option<String>,
 }
 
 impl CreateQueryLinkBuilder {
@@ -28,6 +29,7 @@ impl CreateQueryLinkBuilder {
                 ..Default::default()
             },
             file_name: None,
+            base_url: None,
             http_client,
         }
     }
@@ -53,6 +55,12 @@ impl CreateQueryLinkBuilder {
     /// Set the file name for the query link.
     pub fn file_name(mut self, file_name: &str) -> Self {
         self.file_name = Some(file_name.to_string());
+        self
+    }
+
+    /// Set the base URL for the query link.
+    pub fn base_url(mut self, base_url: &str) -> Self {
+        self.request.base_url = Some(base_url.to_string());
         self
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature/Bugfix

### What was changed?

The base_url is a  part of v1.17.0 HTTP API. 

### Related issues

https://github.com/reductstore/web-console/issues/151

### Does this PR introduce a breaking change?

No

### Other information:
