### PR TITLE
Add support for replication mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         reductstore_version: [ "main", "latest" ]
         include:
           - reductstore_version: main
-            features: "default,test-api-117"
+            features: "default,test-api-118"
           - reductstore_version: latest
             features: "default"
     needs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Library entry is `src/lib.rs`; client surface is split into `client.rs`, `http_client.rs`, and feature modules under `src/bucket`, `src/record`, and `src/replication.rs`.
+- Examples demonstrating API usage live in `examples/hallo_world.rs` and `examples/query.rs`; use them as runnable docs.
+- Tests sit next to the code inside `mod tests` blocks and rely on async Tokio + `rstest`; there is no standalone `tests/` folder.
+- `Cargo.toml` pins Rust 1.89 (edition 2021) and defines the `test-api-117` feature used for compatibility checks against older API behavior.
+
+## Build, Test, and Development Commands
+- `cargo fmt --all` — required by CI; keep it clean before pushing.
+- `cargo check` — fast sanity compile (also wired in pre-commit).
+- `cargo build --release` — produce optimized artifacts.
+- Start ReductStore locally before tests: `docker run --rm --network host -e RS_API_TOKEN=TOKEN reduct/store:latest` (expects HTTP on `127.0.0.1:8383`).
+- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1` — main test suite; use `--features "default,test-api-117"` to exercise the backward-compat matrix.
+- `cargo run --example hallo_world` (or `query`) — run examples against the local server.
+
+## Coding Style & Naming Conventions
+- Rustfmt defaults (4-space indent) are the source of truth; run before review.
+- Use snake_case for modules/functions, CamelCase for types/traits, and SCREAMING_SNAKE_CASE for consts; mirror existing builder/async patterns for new APIs.
+- Prefer small, composable functions; propagate errors with `Result<T, ReductError>` like existing calls.
+- Optional: install pre-commit (`pre-commit install`) to mirror CI hooks (`fmt`, `cargo-check`, whitespace fixes).
+
+## Testing Guidelines
+- Tests are async (`#[tokio::test]`) and fixture-driven via `rstest`; add new cases beside the relevant module.
+- Some replication/license checks are gated by `test-with` and only run if `misc/lic.key` exists; keep them optional but working.
+- Tests assume a clean server state and remove `test-*` resources; follow that pattern for new setups to avoid cross-test pollution.
+- Document any new env vars or server flags needed for your tests in the PR body.
+
+## Commit & Pull Request Guidelines
+- Commit messages are short and imperative; include scope or issue/PR numbers when helpful (e.g., `Add base_url to Bucket.create_query_link (#51)`), and use `release vX.Y.Z` for tagged releases.
+- PRs should describe the change, API versions or features touched, and list the commands you ran (fmt/check/tests/examples).
+- Link related issues, call out breaking or backward-compat implications, and keep secrets (tokens, licenses) out of commits by using env vars instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for replication mode, [PR-53](https://github.com/reductstore/reduct-rs/pull/53)
+
 ## 1.17.2 - 2025-12-17
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test-api-117 = []   # Test API 1.16
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = "1.17.3"
+reduct-base = { version = "1.18.0", git = "https://github.com/reductstore/reductstore.git"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "cookies"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database"]
 
 [features]
 default = []
-test-api-117 = []   # Test API 1.16
+test-api-118 = []
 
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ database for unstructured data.
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.17](https://www.reduct.store/docs/http-api)
+* Supports the [ReductStore HTTP API v1.18](https://www.reduct.store/docs/http-api)
 * Built on top of [reqwest](https://github.com/seanmonstar/reqwest)
 * Asynchronous API
 
@@ -90,9 +90,9 @@ The library is backward compatible with the previous versions. However, some met
 removed in the future releases. Please refer to the [Changelog](CHANGELOG.md) for more details.
 The SDK supports the following ReductStore API versions:
 
+* v1.18
 * v1.17
 * v1.16
-* v1.15
 
 It can work with newer and older versions, but it is not guaranteed that all features will work as expected because
 the API may change and some features may be deprecated or the SDK may not support them yet.

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -107,7 +107,6 @@ mod tests {
     use reduct_base::msg::entry_api::QueryEntry;
     use rstest::rstest;
 
-    #[cfg(feature = "test-api-117")]
     #[rstest]
     #[tokio::test]
     async fn test_link_creation(#[future] bucket: Bucket) {
@@ -123,7 +122,6 @@ mod tests {
         assert_eq!(body, "Hey entry-1!");
     }
 
-    #[cfg(feature = "test-api-117")]
     #[rstest]
     #[tokio::test]
     async fn test_link_creation_with_query(#[future] bucket: Bucket) {
@@ -141,7 +139,6 @@ mod tests {
         assert_eq!(body, "Hey entry-1!");
     }
 
-    #[cfg(feature = "test-api-117")]
     #[rstest]
     #[tokio::test]
     async fn test_link_creation_with_index(#[future] bucket: Bucket) {
@@ -156,7 +153,6 @@ mod tests {
         assert_eq!(body, r#"{"detail": "Record number out of range"}"#)
     }
 
-    #[cfg(feature = "test-api-117")]
     #[rstest]
     #[tokio::test]
     async fn test_link_creation_expired(#[future] bucket: Bucket) {
@@ -171,7 +167,6 @@ mod tests {
         assert_eq!(response.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
     }
 
-    #[cfg(feature = "test-api-117")]
     #[rstest]
     #[tokio::test]
     async fn test_link_creation_file_name(#[future] bucket: Bucket) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ pub use reduct_base::error::{ErrorCode, ReductError};
 pub use reduct_base::msg::bucket_api::{BucketInfo, BucketSettings, FullBucketInfo, QuotaType};
 pub use reduct_base::msg::entry_api::EntryInfo;
 pub use reduct_base::msg::replication_api::{
-    FullReplicationInfo, ReplicationInfo, ReplicationList, ReplicationSettings,
+    FullReplicationInfo, ReplicationInfo, ReplicationList, ReplicationMode, ReplicationModePayload,
+    ReplicationSettings,
 };
 pub use reduct_base::msg::server_api::{BucketInfoList, Defaults, ServerInfo};
 pub use reduct_base::msg::token_api::{Permissions, Token};

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -6,7 +6,7 @@
 use crate::client::Result;
 use crate::http_client::HttpClient;
 
-use reduct_base::msg::replication_api::ReplicationSettings;
+use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
 use reqwest::Method;
 use std::sync::Arc;
 
@@ -20,20 +20,12 @@ pub struct ReplicationBuilder {
 impl ReplicationBuilder {
     /// Create a new replication builder.
     pub(super) fn new(name: String, http_client: Arc<HttpClient>) -> Self {
+        let mut settings = ReplicationSettings::default();
+        // Keep compatibility with older ReductStore versions that expect an empty token field.
+        settings.dst_token = Some("".to_string());
         Self {
             name,
-            settings: ReplicationSettings {
-                src_bucket: "".to_string(),
-                dst_bucket: "".to_string(),
-                dst_host: "".to_string(),
-                dst_token: Some("".to_string()), // for compatibility with v1.16.0 and earlier
-                entries: vec![],
-                include: Default::default(),
-                exclude: Default::default(),
-                each_s: None,
-                each_n: None,
-                when: None,
-            },
+            settings,
             http_client,
         }
     }
@@ -126,6 +118,14 @@ impl ReplicationBuilder {
     /// * `when` - Conditional query.
     pub fn when(mut self, when: serde_json::Value) -> Self {
         self.settings.when = Some(when);
+        self
+    }
+
+    /// Set replication mode.
+    ///
+    /// * `mode` - Enabled, Paused, or Disabled.
+    pub fn mode(mut self, mode: ReplicationMode) -> Self {
+        self.settings.mode = mode;
         self
     }
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added replication mode support (enabled/paused/disabled) to the Rust SDK: re-exported new types, defaulted settings to include mode, and added set_replication_mode to hit the new PATCH endpoint.
- Updated replication builder/tests to carry mode through settings and info assertions, keeping legacy compatibility by seeding dst_token for older servers.
- Bumped reduct-base to the upstream git 1.18.0 snapshot that includes the mode API definitions.
  

### Related issues

https://github.com/reductstore/reductstore/pull/1065

### Does this PR introduce a breaking change?

No

### Other information:
