### PR TITLE
Add multi-entry query link support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for replication mode, [PR-53](https://github.com/reductstore/reduct-rs/pull/53)
 - Add `ResourceStatus` enum for non-blocking deletion support (READY/DELETING), [PR-55](https://github.com/reductstore/reduct-rs/pull/55)
 - Add support for Multi-entry API, [PR-60](https://github.com/reductstore/reduct-rs/pull/60)
-- Add multi-entry query link support (API v1.18+), [PR-60](https://github.com/reductstore/reduct-rs/pull/60)
+- Add multi-entry query link support (API v1.18+), [PR-61](https://github.com/reductstore/reduct-rs/pull/61)
 
 ## 1.17.2 - 2025-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for replication mode, [PR-53](https://github.com/reductstore/reduct-rs/pull/53)
 - Add `ResourceStatus` enum for non-blocking deletion support (READY/DELETING), [PR-55](https://github.com/reductstore/reduct-rs/pull/55)
 - Add support for Multi-entry API, [PR-60](https://github.com/reductstore/reduct-rs/pull/60)
+- Add multi-entry query link support (API v1.18+), [PR-60](https://github.com/reductstore/reduct-rs/pull/60)
 
 ## 1.17.2 - 2025-12-17
 

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -166,7 +166,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "api_v1_18")]
+    #[cfg(feature = "test-api-118")]
     async fn test_link_creation_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         let link = bucket

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -166,6 +166,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    #[cfg(feature = "api_v1_18")]
     async fn test_link_creation_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         let link = bucket

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -81,9 +81,14 @@ impl CreateQueryLinkBuilder {
             request.query.entries = Some(self.entries.clone());
         }
 
+        let default_name = if self.entries.len() > 1 {
+            request.bucket.clone()
+        } else {
+            request.entry.clone()
+        };
         let file_name = self.file_name.unwrap_or(format!(
             "{}_{}.bin",
-            request.entry,
+            default_name,
             request.index.unwrap_or(0)
         ));
         let response: QueryLinkCreateResponse = self
@@ -173,6 +178,7 @@ mod tests {
             .await
             .unwrap();
 
+        assert!(link.contains("links/test-bucket-1_"));
         let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
         assert_eq!(body, "Hey entry-1!");
     }


### PR DESCRIPTION
Closes #50

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Add multi-entry query link creation with API v1.18+ guard.
- Add test coverage for multi-entry query links.
- Update `CHANGELOG.md` for multi-entry query link support.

### Related issues

- https://github.com/reductstore/reduct-rs/issues/50

### Does this PR introduce a breaking change?

No

### Other information:

Commands run:
- `cargo check`

Not run (recommended by repo):
- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1`
- `RS_API_TOKEN=TOKEN cargo test --features "default,test-api-118" -- --test-threads=1`
- Run against both `reduct/store:latest` and `reduct/store:main`.
