### PR TITLE
Add support for entry attachments

### DIFF
--- a/.codex/skills/create-pr/SKILL.md
+++ b/.codex/skills/create-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: create-pr
+description: Create GitHub pull requests with the gh CLI using the reductstore/.github PR template, then update CHANGELOG.md with the created PR ID and commit the changelog (do not push). Use when a user asks to open a PR and record its ID in the changelog.
+---
+
+# Create Pr
+
+## Overview
+
+Create a PR using the standardized template from reductstore/.github, then record the PR number in CHANGELOG.md and commit the changelog without pushing.
+
+## Workflow
+
+### 1) Preconditions
+- Ensure `gh auth status` is logged in and the current branch is the intended PR branch.
+- Ensure the working tree is clean (or only the intended changes are present).
+- Use context from the current conversation to infer intent, scope, and any constraints.
+
+### 2) Understand changes and rationale
+- Compare the current branch against `main` to understand what changed and why (use this to derive the PR title, description, and rationale):
+  - `git fetch origin main`
+  - `git log --oneline origin/main..HEAD`
+  - `git diff --stat origin/main...HEAD`
+  - `git diff origin/main...HEAD`
+- If the branch name starts with an issue number (e.g., `123-...`), use that issue in the rationale and fill the `Closes #` line in the PR template.
+- If the branch name does not include an issue number, infer the likely issue from changes and conversation context, or leave `Closes #` empty if unsure.
+
+### 3) Fetch the PR template
+Use the helper script to download the latest PR template from reductstore/.github:
+
+```bash
+./.codex/skills/create-pr/scripts/fetch_pr_template.sh /tmp/pr_template.md
+```
+
+Fill in the template file with the relevant summary, testing, and rationale derived from the diff and conversation context.
+
+### 4) Create the PR with gh
+Use the filled template as the PR body:
+
+```bash
+gh pr create --title "<title>" --body-file /tmp/pr_template.md
+```
+
+Capture the PR number after creation:
+
+```bash
+gh pr view --json number -q .number
+```
+
+### 5) Update CHANGELOG.md
+- Find the appropriate section (usually the most recent/unreleased section).
+- Add a new entry following the existing style in the file.
+- Include the PR ID as `#<number>` exactly as prior entries do.
+
+### 6) Commit (no push)
+Stage and commit the changelog update only:
+
+```bash
+git add CHANGELOG.md
+git commit -m "Update changelog for PR #<number>"
+```
+
+Do not push.
+
+## Resources
+
+### scripts/
+- `fetch_pr_template.sh`: Download the latest PR template from reductstore/.github.

--- a/.codex/skills/create-pr/scripts/fetch_pr_template.sh
+++ b/.codex/skills/create-pr/scripts/fetch_pr_template.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <output-file>" >&2
+  exit 1
+fi
+
+output_file="$1"
+
+curl -sS -L \
+  "https://raw.githubusercontent.com/reductstore/.github/main/.github/pull_request_template.md" \
+  -o "$output_file"
+
+if [[ ! -s "$output_file" ]]; then
+  echo "Template download failed or empty: $output_file" >&2
+  exit 1
+fi
+
+echo "Template saved to $output_file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         reductstore_version: [ "main", "latest" ]
         include:
           - reductstore_version: main
-            features: "default,test-api-118"
+            features: "default,test-api-119"
           - reductstore_version: latest
             features: "default"
     needs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,14 @@
 - Library entry is `src/lib.rs`; client surface is split into `client.rs`, `http_client.rs`, and feature modules under `src/bucket`, `src/record`, and `src/replication.rs`.
 - Examples demonstrating API usage live in `examples/hallo_world.rs` and `examples/query.rs`; use them as runnable docs.
 - Tests sit next to the code inside `mod tests` blocks and rely on async Tokio + `rstest`; there is no standalone `tests/` folder.
-- `Cargo.toml` pins Rust 1.89 (edition 2021) and defines the `test-api-118` feature used for compatibility checks against older API behavior.
+- `Cargo.toml` pins Rust 1.89 (edition 2021) and defines the `test-api-119` feature used for compatibility checks against older API behavior.
 
 ## Build, Test, and Development Commands
 - `cargo fmt --all` — required by CI; keep it clean before pushing.
 - `cargo check` — fast sanity compile (also wired in pre-commit).
 - `cargo build --release` — produce optimized artifacts.
 - Start ReductStore locally before tests: `docker run --rm --network host -e RS_API_TOKEN=TOKEN reduct/store:latest` (expects HTTP on `127.0.0.1:8383`).
-- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1` — main test suite; use `--features "default,test-api-118"` to exercise the backward-compat matrix (dev branch).
+- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1` — main test suite; use `--features "default,test-api-119"` to exercise the backward-compat matrix (dev branch).
 - `cargo run --example hallo_world` (or `query`) — run examples against the local server.
 
 ## Coding Style & Naming Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for entry attachments, [PR-66](https://github.com/reductstore/reduct-rs/pull/66)
+
 ## 1.18.0 - 2026-02-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database"]
 
 [features]
 default = []
-test-api-118 = []
+test-api-119 = []
 
 
 [lib]

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -3,6 +3,7 @@
 //    License, v. 2.0. If a copy of the MPL was not distributed with this
 //    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod attachments;
 mod link;
 mod read;
 mod remove;

--- a/src/bucket/attachments.rs
+++ b/src/bucket/attachments.rs
@@ -1,0 +1,221 @@
+// Copyright 2026 ReductStore
+// This Source Code Form is subject to the terms of the Mozilla Public
+//    License, v. 2.0. If a copy of the MPL was not distributed with this
+//    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::{Bucket, RecordBuilder};
+use futures_util::{pin_mut, StreamExt};
+use reduct_base::error::{ErrorCode, ReductError};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+impl Bucket {
+    /// Write entry attachments.
+    ///
+    /// Attachments are stored in a hidden metadata entry `<entry>/$meta` as JSON payloads
+    /// with the `key` label containing the attachment name.
+    pub async fn write_attachments(
+        &self,
+        entry: &str,
+        attachments: HashMap<String, Value>,
+    ) -> Result<(), ReductError> {
+        let meta_entry = format!("{entry}/$meta");
+        let mut batch = self.write_record_batch();
+        if attachments.is_empty() {
+            return Ok(());
+        }
+
+        let mut timestamp_us = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("SystemTime must be after UNIX_EPOCH")
+            .as_micros() as u64;
+
+        for (key, content) in attachments {
+            let payload = serde_json::to_vec(&content).map_err(|err| {
+                ReductError::new(
+                    ErrorCode::UnprocessableEntity,
+                    &format!("failed to serialize attachment '{key}': {err}"),
+                )
+            })?;
+            batch = batch.add_record(
+                RecordBuilder::new()
+                    .entry(meta_entry.clone())
+                    .timestamp_us(timestamp_us)
+                    .data(payload)
+                    .content_type("application/json")
+                    .add_label("key".to_string(), key)
+                    .build(),
+            );
+            timestamp_us += 1;
+        }
+
+        batch.send().await?;
+        Ok(())
+    }
+
+    /// Read entry attachments.
+    ///
+    /// Returns a map where keys are attachment names and values are JSON payloads.
+    pub async fn read_attachments(
+        &self,
+        entry: &str,
+    ) -> Result<HashMap<String, Value>, ReductError> {
+        let mut attachments = HashMap::new();
+        let query = self.query(format!("{entry}/$meta")).send().await?;
+        pin_mut!(query);
+
+        while let Some(record) = query.next().await {
+            let record = record?;
+            let key = record.labels().get("key").cloned();
+            if let Some(key) = key {
+                let content = record.bytes().await?;
+                let metadata = serde_json::from_slice(&content).map_err(|err| {
+                    ReductError::new(
+                        ErrorCode::UnprocessableEntity,
+                        &format!("failed to decode attachment '{key}': {err}"),
+                    )
+                })?;
+                attachments.insert(key.clone(), metadata);
+            }
+        }
+
+        Ok(attachments)
+    }
+
+    /// Remove entry attachments.
+    ///
+    /// If `attachment_keys` is `None`, all attachments are removed.
+    pub async fn remove_attachments(
+        &self,
+        entry: &str,
+        attachment_keys: Option<Vec<String>>,
+    ) -> Result<(), ReductError> {
+        let meta_entry = format!("{entry}/$meta");
+        let mut batch = self.update_record_batch();
+
+        let query = if let Some(keys) = attachment_keys {
+            let mut when = vec![json!("&key")];
+            when.extend(keys.into_iter().map(Value::from));
+            self.query(meta_entry.clone())
+                .when(json!({"$in": when}))
+                .send()
+                .await?
+        } else {
+            self.query(meta_entry.clone()).send().await?
+        };
+
+        pin_mut!(query);
+        while let Some(record) = query.next().await {
+            let record = record?;
+            let mut labels = record.labels().clone();
+            labels.insert("remove".to_string(), "true".to_string());
+
+            batch = batch.add_record(
+                RecordBuilder::new()
+                    .entry(record.entry())
+                    .timestamp_us(record.timestamp_us())
+                    .labels(labels)
+                    .build(),
+            );
+        }
+
+        if batch.record_count() == 0 {
+            return Ok(());
+        }
+
+        batch.send().await?;
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "test-api-119"))]
+mod tests {
+    use crate::bucket::tests::bucket;
+    use crate::Bucket;
+    use rstest::{fixture, rstest};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    const ENTRY: &str = "entry-1";
+
+    #[fixture]
+    fn complex_attachments() -> HashMap<String, serde_json::Value> {
+        HashMap::from([
+            (
+                "meta-1".to_string(),
+                json!({"enabled": true, "values": [1, 2, 3]}),
+            ),
+            ("meta-2".to_string(), json!({"name": "test"})),
+        ])
+    }
+
+    #[fixture]
+    fn removable_attachments() -> HashMap<String, serde_json::Value> {
+        HashMap::from([
+            ("meta-1".to_string(), json!({"value": 1})),
+            ("meta-2".to_string(), json!({"value": 2})),
+        ])
+    }
+
+    #[fixture]
+    fn selected_after_remove() -> HashMap<String, serde_json::Value> {
+        HashMap::from([("meta-2".to_string(), json!({"value": 2}))])
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_write_read_attachments(
+        #[future] bucket: Bucket,
+        complex_attachments: HashMap<String, serde_json::Value>,
+    ) {
+        let bucket = bucket.await;
+        bucket
+            .write_attachments(ENTRY, complex_attachments.clone())
+            .await
+            .unwrap();
+
+        let attachments = bucket.read_attachments(ENTRY).await.unwrap();
+        assert_eq!(attachments, complex_attachments);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_selected_attachments(
+        #[future] bucket: Bucket,
+        removable_attachments: HashMap<String, serde_json::Value>,
+        selected_after_remove: HashMap<String, serde_json::Value>,
+    ) {
+        let bucket = bucket.await;
+        bucket
+            .write_attachments(ENTRY, removable_attachments)
+            .await
+            .unwrap();
+
+        bucket
+            .remove_attachments(ENTRY, Some(vec!["meta-1".to_string()]))
+            .await
+            .unwrap();
+
+        let attachments = bucket.read_attachments(ENTRY).await.unwrap();
+        assert_eq!(attachments, selected_after_remove);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_all_attachments(
+        #[future] bucket: Bucket,
+        removable_attachments: HashMap<String, serde_json::Value>,
+    ) {
+        let bucket = bucket.await;
+        bucket
+            .write_attachments(ENTRY, removable_attachments)
+            .await
+            .unwrap();
+
+        bucket.remove_attachments(ENTRY, None).await.unwrap();
+
+        let attachments = bucket.read_attachments(ENTRY).await.unwrap();
+        assert_eq!(attachments, HashMap::new());
+    }
+}

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -166,7 +166,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn test_link_creation_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         let link = bucket

--- a/src/bucket/read.rs
+++ b/src/bucket/read.rs
@@ -226,7 +226,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn test_query_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         let query = bucket.query(&["entry-1", "entry-2"]).send().await.unwrap();

--- a/src/bucket/remove.rs
+++ b/src/bucket/remove.rs
@@ -210,7 +210,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn remove_batch_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         bucket
@@ -264,7 +263,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn remove_batch_multi_entry_with_error(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         bucket
@@ -336,7 +334,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn remove_query_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
 

--- a/src/bucket/update.rs
+++ b/src/bucket/update.rs
@@ -176,7 +176,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn test_update_record_batched_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         bucket
@@ -242,7 +241,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn test_update_record_batched_multi_entry_with_error(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         bucket

--- a/src/bucket/write.rs
+++ b/src/bucket/write.rs
@@ -223,7 +223,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn test_batched_write_multi_entry(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         let batch = bucket.write_record_batch();
@@ -267,7 +266,6 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    #[cfg(feature = "test-api-118")]
     async fn test_batched_write_multi_entry_with_error(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         bucket

--- a/src/client.rs
+++ b/src/client.rs
@@ -671,7 +671,6 @@ pub(crate) mod tests {
 
         #[rstest]
         #[tokio::test]
-        #[cfg(feature = "test-api-118")]
         async fn test_set_replication_mode(
             #[future] client: ReductClient,
             settings: ReplicationSettings,


### PR DESCRIPTION
Closes #49

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Add attachment APIs on `Bucket`:
  - `write_attachments(entry, HashMap<String, Value>)`
  - `read_attachments(entry)`
  - `remove_attachments(entry, Option<Vec<String>>)`
- Store attachments in hidden metadata entry `<entry>/$meta` with JSON payload and `key` label.
- Add integration tests for write/read/remove attachment flows under `test-api-119`.
- Rename compatibility feature flag from `test-api-118` to `test-api-119` in `Cargo.toml`, CI matrix, and AGENTS docs.
- Remove legacy `#[cfg(feature = "test-api-118")]` gates from multi-entry tests and align with current API compatibility checks.

### Related issues

- https://github.com/reductstore/reduct-rs/issues/49

### Does this PR introduce a breaking change?

No.

### Other information:

The attachment tests are feature-gated with `test-api-119`.
