### PR TITLE
Fix remove_attachments for numeric attachment keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for entry attachments, [PR-66](https://github.com/reductstore/reduct-rs/pull/66)
 
+### Fixed
+
+- Fix removing attachments with numeric keys, [PR-67](https://github.com/reductstore/reduct-rs/pull/67)
+
 ## 1.18.0 - 2026-02-04
 
 ### Added

--- a/src/bucket/attachments.rs
+++ b/src/bucket/attachments.rs
@@ -95,7 +95,7 @@ impl Bucket {
         let mut batch = self.update_record_batch();
 
         let query = if let Some(keys) = attachment_keys {
-            let mut when = vec![json!("&key")];
+            let mut when = vec![json!({"&key": {"$cast": "string"}})];
             when.extend(keys.into_iter().map(Value::from));
             self.query(meta_entry.clone())
                 .when(json!({"$in": when}))
@@ -199,6 +199,45 @@ mod tests {
 
         let attachments = bucket.read_attachments(ENTRY).await.unwrap();
         assert_eq!(attachments, selected_after_remove);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_attachments_with_numeric_keys(#[future] bucket: Bucket) {
+        let bucket = bucket.await;
+        bucket
+            .write_attachments(
+                ENTRY,
+                HashMap::from([
+                    (
+                        "1".to_string(),
+                        json!({"enabled": true, "values": [1, 2, 3]}),
+                    ),
+                    ("2.5".to_string(), json!({"name": "test"})),
+                ]),
+            )
+            .await
+            .unwrap();
+
+        let attachments = bucket.read_attachments(ENTRY).await.unwrap();
+        assert_eq!(
+            attachments,
+            HashMap::from([
+                (
+                    "1".to_string(),
+                    json!({"enabled": true, "values": [1, 2, 3]})
+                ),
+                ("2.5".to_string(), json!({"name": "test"})),
+            ])
+        );
+
+        bucket
+            .remove_attachments(ENTRY, Some(vec!["1".to_string(), "2.5".to_string()]))
+            .await
+            .unwrap();
+
+        let attachments = bucket.read_attachments(ENTRY).await.unwrap();
+        assert_eq!(attachments, HashMap::new());
     }
 
     #[rstest]


### PR DESCRIPTION
Closes reductstore/reductstore#1197

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Fixed `Bucket::remove_attachments` filtering when removing attachments whose keys are numeric strings.
- Updated the query predicate to cast `&key` to string before applying `$in`, so keys like `"1"` and `"2.5"` match reliably.
- Added a regression test for numeric attachment keys in `src/bucket/attachments.rs`.

### Related issues

- reductstore/reductstore#1197

### Does this PR introduce a breaking change?

No.

### Other information:

- Verified with: `RS_API_TOKEN=TOKEN cargo test test_remove_attachments_with_numeric_keys --features "default,test-api-119" -- --test-threads=1`
