### PR TITLE
chore: bump reqwest 0.12 -> 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["lib"]
 reduct-base = { version = "1.18.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "cookies"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "cookies"] }
 http = "1.0.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 bytes = "1.4.0"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Dependency update

### What was changed?

Updated the `reqwest` dependency from `0.12` to `0.13` and renamed the `rustls-tls` feature to `rustls` to match the updated feature name in `reqwest 0.13`.

### Related issues

Looks like dependabot here: https://github.com/reductstore/reduct-rs/pull/59, but maybe that was closed inadvertently?  The changes definitely did not land.

### Does this PR introduce a breaking change?

No. The `reqwest` API surface used by this crate is identical between 0.12 and 0.13. The only change is the TLS feature name: `rustls-tls` was renamed to `rustls` in reqwest 0.13.

### Other information:
