### PR TITLE
Fix removal of system attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix removing attachments with numeric keys, [PR-67](https://github.com/reductstore/reduct-rs/pull/67)
+- Fix removing attachments whose keys start with `$`, [#70](https://github.com/reductstore/reduct-rs/issues/70)
 
 ## 1.18.0 - 2026-02-04
 

--- a/src/bucket/attachments.rs
+++ b/src/bucket/attachments.rs
@@ -96,6 +96,8 @@ impl Bucket {
 
         let query = if let Some(keys) = attachment_keys {
             let mut when = vec![json!({"&key": {"$cast": "string"}})];
+            // Escape "$"-prefixed keys so the ReductStore query engine treats
+            // them as literal values instead of operators such as $$system.
             let escaped_keys = keys
                 .into_iter()
                 .map(|key| {

--- a/src/bucket/attachments.rs
+++ b/src/bucket/attachments.rs
@@ -96,7 +96,17 @@ impl Bucket {
 
         let query = if let Some(keys) = attachment_keys {
             let mut when = vec![json!({"&key": {"$cast": "string"}})];
-            when.extend(keys.into_iter().map(Value::from));
+            let escaped_keys = keys
+                .into_iter()
+                .map(|key| {
+                    if key.starts_with('$') {
+                        format!("${}", key)
+                    } else {
+                        key
+                    }
+                })
+                .collect::<Vec<_>>();
+            when.extend(escaped_keys.into_iter().map(Value::from));
             self.query(meta_entry.clone())
                 .when(json!({"$in": when}))
                 .send()
@@ -155,6 +165,7 @@ mod tests {
         HashMap::from([
             ("meta-1".to_string(), json!({"value": 1})),
             ("meta-2".to_string(), json!({"value": 2})),
+            ("$system".to_string(), json!({"value": "test"})),
         ])
     }
 
@@ -193,12 +204,38 @@ mod tests {
             .unwrap();
 
         bucket
-            .remove_attachments(ENTRY, Some(vec!["meta-1".to_string()]))
+            .remove_attachments(
+                ENTRY,
+                Some(vec!["meta-1".to_string(), "$system".to_string()]),
+            )
             .await
             .unwrap();
 
         let attachments = bucket.read_attachments(ENTRY).await.unwrap();
         assert_eq!(attachments, selected_after_remove);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_remove_system_attachment_only(
+        #[future] bucket: Bucket,
+        removable_attachments: HashMap<String, serde_json::Value>,
+    ) {
+        let bucket = bucket.await;
+        bucket
+            .write_attachments(ENTRY, removable_attachments)
+            .await
+            .unwrap();
+
+        bucket
+            .remove_attachments(ENTRY, Some(vec!["$system".to_string()]))
+            .await
+            .unwrap();
+
+        let attachments = bucket.read_attachments(ENTRY).await.unwrap();
+        assert!(!attachments.contains_key("$system"));
+        assert!(attachments.contains_key("meta-1"));
+        assert!(attachments.contains_key("meta-2"));
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #70

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix.

### What was changed?

- Escape attachment keys that begin with `$` before constructing the `$in` filter so that ReductStore treats them as literals instead of operators.
- Extend the attachment-removal tests to cover `$system` keys (both combined with normal attachments and on their own).
- Add the regression note to the Unreleased changelog.

### Related issues

- #70

### Does this PR introduce a breaking change?

No.

### Other information:

Verification:
- `cargo fmt --all`
- `cargo check`

Integration tests that exercise attachment removal require a running ReductStore instance (per AGENTS.md); Docker is not available in this environment, so those were not executed here.
