### PR TITLE
feat(token): support token API create options, rotation, and info fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for entry attachments, [PR-66](https://github.com/reductstore/reduct-rs/pull/66)
 - Add `ca_cert_path` option to `ReductClientBuilder`, [PR-69](https://github.com/reductstore/reduct-rs/pull/69)
+- Add token API v2 support with `create_token_with_options`, `rotate_token`, and extended token info methods (`me_info`, `get_token_info`, `list_tokens_info`), [PR-73](https://github.com/reductstore/reduct-rs/pull/73)
 
 ### Fixed
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@
 use crate::bucket::BucketBuilder;
 use crate::http_client::HttpClient;
 use crate::replication::ReplicationBuilder;
+use crate::token::{TokenCreateOptions, TokenInfo, TokenInfoList};
 use crate::Bucket;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::replication_api::{
@@ -263,26 +264,53 @@ impl ReductClient {
             .await
     }
 
-    /// Create an access token
+    /// Get extended token info for the current user.
+    pub async fn me_info(&self) -> Result<TokenInfo> {
+        self.http_client
+            .send_and_receive_json::<(), TokenInfo>(Method::GET, "/me", None)
+            .await
+    }
+
+    /// Create an access token.
     ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the token
-    /// * `permissions` - The permissions of the token
-    ///
-    /// # Returns
-    ///
-    /// The token value or HttpError
+    /// Deprecated: use [`Self::create_token_with_options`] for full API support.
     pub async fn create_token(&self, name: &str, permissions: Permissions) -> Result<String> {
         let token = self
-            .http_client
-            .send_and_receive_json::<Permissions, TokenCreateResponse>(
-                Method::POST,
-                &format!("/tokens/{}", name),
-                Some(permissions),
+            .create_token_with_options(
+                name,
+                TokenCreateOptions {
+                    permissions,
+                    ..Default::default()
+                },
             )
             .await?;
         Ok(token.value)
+    }
+
+    /// Create an access token with extended options (`expires_at`, `ttl`, `ip_allowlist`).
+    pub async fn create_token_with_options(
+        &self,
+        name: &str,
+        options: TokenCreateOptions,
+    ) -> Result<TokenCreateResponse> {
+        self.http_client
+            .send_and_receive_json::<TokenCreateOptions, TokenCreateResponse>(
+                Method::POST,
+                &format!("/tokens/{}", name),
+                Some(options),
+            )
+            .await
+    }
+
+    /// Rotate an access token value and revoke the old one.
+    pub async fn rotate_token(&self, name: &str) -> Result<TokenCreateResponse> {
+        self.http_client
+            .send_and_receive_json::<(), TokenCreateResponse>(
+                Method::POST,
+                &format!("/tokens/{}/rotate", name),
+                None,
+            )
+            .await
     }
 
     /// Get an access token
@@ -297,6 +325,13 @@ impl ReductClient {
     pub async fn get_token(&self, name: &str) -> Result<Token> {
         self.http_client
             .send_and_receive_json::<(), Token>(Method::GET, &format!("/tokens/{}", name), None)
+            .await
+    }
+
+    /// Get extended access token info.
+    pub async fn get_token_info(&self, name: &str) -> Result<TokenInfo> {
+        self.http_client
+            .send_and_receive_json::<(), TokenInfo>(Method::GET, &format!("/tokens/{}", name), None)
             .await
     }
 
@@ -326,6 +361,15 @@ impl ReductClient {
         let list = self
             .http_client
             .send_and_receive_json::<(), TokenList>(Method::GET, "/tokens", None)
+            .await?;
+        Ok(list.tokens)
+    }
+
+    /// List all access tokens with extended fields.
+    pub async fn list_tokens_info(&self) -> Result<Vec<TokenInfo>> {
+        let list = self
+            .http_client
+            .send_and_receive_json::<(), TokenInfoList>(Method::GET, "/tokens", None)
             .await?;
         Ok(list.tokens)
     }
@@ -640,6 +684,14 @@ YyRIHN8wfdVoOw==
 
         #[rstest]
         #[tokio::test]
+        async fn test_me_info(#[future] client: ReductClient) {
+            let token = client.await.me_info().await.unwrap();
+            assert_eq!(token.name, "init-token");
+            assert!(token.permissions.unwrap().full_access);
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_create_token(#[future] client: ReductClient) {
             let token_value = client
                 .await
@@ -659,6 +711,30 @@ YyRIHN8wfdVoOw==
 
         #[rstest]
         #[tokio::test]
+        async fn test_create_token_with_options(#[future] client: ReductClient) {
+            let token = client
+                .await
+                .create_token_with_options(
+                    "test-token-options",
+                    TokenCreateOptions {
+                        permissions: Permissions {
+                            full_access: false,
+                            read: vec!["test-bucket".to_string()],
+                            write: vec!["test-bucket".to_string()],
+                        },
+                        ttl: Some(3600),
+                        ip_allowlist: vec!["127.0.0.1".to_string()],
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert!(token.value.starts_with("test-token-options"));
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_get_token(#[future] client: ReductClient) {
             let token = client.await.get_token("init-token").await.unwrap();
             assert_eq!(token.name, "init-token");
@@ -672,9 +748,37 @@ YyRIHN8wfdVoOw==
 
         #[rstest]
         #[tokio::test]
+        async fn test_get_token_info(#[future] client: ReductClient) {
+            let token = client.await.get_token_info("init-token").await.unwrap();
+            assert_eq!(token.name, "init-token");
+            assert!(token.is_provisioned);
+        }
+
+        #[rstest]
+        #[tokio::test]
         async fn test_list_tokens(#[future] client: ReductClient) {
             let tokens = client.await.list_tokens().await.unwrap();
             assert!(!tokens.is_empty());
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_list_tokens_info(#[future] client: ReductClient) {
+            let tokens = client.await.list_tokens_info().await.unwrap();
+            assert!(!tokens.is_empty());
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_rotate_token(#[future] client: ReductClient) {
+            let client = client.await;
+            client
+                .create_token("test-token-rotate", Permissions::default())
+                .await
+                .unwrap();
+            let rotated = client.rotate_token("test-token-rotate").await.unwrap();
+            assert!(rotated.value.starts_with("test-token-rotate"));
+            client.delete_token("test-token-rotate").await.unwrap();
         }
 
         #[rstest]

--- a/src/client.rs
+++ b/src/client.rs
@@ -709,6 +709,7 @@ YyRIHN8wfdVoOw==
             assert!(token_value.starts_with("test-token"));
         }
 
+        #[cfg(feature = "test-api-119")]
         #[rstest]
         #[tokio::test]
         async fn test_create_token_with_options(#[future] client: ReductClient) {
@@ -746,6 +747,7 @@ YyRIHN8wfdVoOw==
             assert!(permissions.write.is_empty());
         }
 
+        #[cfg(feature = "test-api-119")]
         #[rstest]
         #[tokio::test]
         async fn test_get_token_info(#[future] client: ReductClient) {
@@ -761,6 +763,7 @@ YyRIHN8wfdVoOw==
             assert!(!tokens.is_empty());
         }
 
+        #[cfg(feature = "test-api-119")]
         #[rstest]
         #[tokio::test]
         async fn test_list_tokens_info(#[future] client: ReductClient) {
@@ -768,6 +771,7 @@ YyRIHN8wfdVoOw==
             assert!(!tokens.is_empty());
         }
 
+        #[cfg(feature = "test-api-119")]
         #[rstest]
         #[tokio::test]
         async fn test_rotate_token(#[future] client: ReductClient) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use reduct_base::msg::replication_api::{
 pub use reduct_base::msg::server_api::{BucketInfoList, Defaults, ServerInfo};
 pub use reduct_base::msg::status::ResourceStatus;
 pub use reduct_base::msg::token_api::{Permissions, Token};
-pub use token::{TokenCreateOptions, TokenInfo, TokenInfoList};
 pub use serde_json::json as condition;
 pub use serde_json::json as ext; // for readability
 pub use serde_json::Value as JsonValue;
+pub use token::{TokenCreateOptions, TokenInfo, TokenInfoList};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod client;
 mod http_client;
 mod record;
 mod replication;
+mod token;
 
 pub use bucket::Bucket;
 pub use client::ReductClient;
@@ -30,6 +31,7 @@ pub use reduct_base::msg::replication_api::{
 pub use reduct_base::msg::server_api::{BucketInfoList, Defaults, ServerInfo};
 pub use reduct_base::msg::status::ResourceStatus;
 pub use reduct_base::msg::token_api::{Permissions, Token};
+pub use token::{TokenCreateOptions, TokenInfo, TokenInfoList};
 pub use serde_json::json as condition;
 pub use serde_json::json as ext; // for readability
 pub use serde_json::Value as JsonValue;

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,43 @@
+use chrono::{DateTime, Utc};
+use reduct_base::msg::token_api::Permissions;
+use serde::{Deserialize, Serialize};
+
+/// Extended token create request payload (API v2).
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct TokenCreateOptions {
+    pub permissions: Permissions,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub ttl: Option<u64>,
+    #[serde(default)]
+    pub ip_allowlist: Vec<String>,
+}
+
+/// Extended token view with token API fields available in newer ReductStore versions.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct TokenInfo {
+    pub name: String,
+    #[serde(default)]
+    pub value: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub permissions: Option<Permissions>,
+    #[serde(default)]
+    pub is_provisioned: bool,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub ttl: Option<u64>,
+    #[serde(default)]
+    pub last_access: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub ip_allowlist: Vec<String>,
+    #[serde(default)]
+    pub is_expired: bool,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+pub struct TokenInfoList {
+    pub tokens: Vec<TokenInfo>,
+}


### PR DESCRIPTION
Closes #56

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature update (Rust SDK compatibility with token API updates).

### What was changed?

- Added new token request/response models in `src/token.rs`:
  - `TokenCreateOptions`
  - `TokenInfo`
  - `TokenInfoList`
- Added new client methods:
  - `create_token_with_options(...)`
  - `rotate_token(...)`
  - `me_info()`
  - `get_token_info(...)`
  - `list_tokens_info()`
- Kept `create_token(...)` as compatibility wrapper that delegates to `create_token_with_options(...)`.
- Added token API tests for new methods and response paths.

### Related issues

- https://github.com/reductstore/reduct-rs/issues/56
- Parent: https://github.com/reductstore/reductstore/issues/1088

### Does this PR introduce a breaking change?

No. Existing `create_token(name, permissions)` calls continue to work.

### Other information:

`cargo check` passes for this branch.
