### PR TITLE
Resolve query-link record identity for index selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Resolve query-link record index selectors to `record_entry` + `record_timestamp` while keeping legacy `index` for compatibility, [#76](https://github.com/reductstore/reduct-rs/issues/76)
 - Fix removing attachments with numeric keys, [PR-67](https://github.com/reductstore/reduct-rs/pull/67)
 - Fix removing attachments whose keys start with `$`, [#70](https://github.com/reductstore/reduct-rs/issues/70)
 

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -7,14 +7,35 @@ use crate::http_client::HttpClient;
 use crate::Bucket;
 use chrono::{DateTime, Utc};
 use http::Method;
-use reduct_base::error::ReductError;
-use reduct_base::msg::entry_api::QueryEntry;
+use reduct_base::batch::sort_headers_by_time;
+use reduct_base::batch::v2::parse_batched_headers;
+use reduct_base::error::{ErrorCode, ReductError};
+use reduct_base::msg::entry_api::{QueryEntry, QueryInfo, QueryType};
 use reduct_base::msg::query_link_api::{QueryLinkCreateRequest, QueryLinkCreateResponse};
+use serde::Serialize;
 use std::sync::Arc;
+
+#[derive(Serialize)]
+struct QueryLinkCreateRequestCompat {
+    bucket: String,
+    entry: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    record_entry: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    record_timestamp: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<u64>,
+    query: QueryEntry,
+    #[serde(serialize_with = "chrono::serde::ts_seconds::serialize")]
+    expire_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_url: Option<String>,
+}
 
 pub struct CreateQueryLinkBuilder {
     entries: Vec<String>,
     request: QueryLinkCreateRequest,
+    selected_index: Option<u64>,
     file_name: Option<String>,
     http_client: Arc<HttpClient>,
 }
@@ -30,6 +51,7 @@ impl CreateQueryLinkBuilder {
                 expire_at: Utc::now() + chrono::Duration::hours(24),
                 ..Default::default()
             },
+            selected_index: None,
             file_name: None,
             http_client,
         }
@@ -43,7 +65,7 @@ impl CreateQueryLinkBuilder {
 
     /// Set the record index for the query link.
     pub fn index(mut self, index: u64) -> Self {
-        self.request.index = Some(index);
+        self.selected_index = Some(index);
         self
     }
 
@@ -67,12 +89,14 @@ impl CreateQueryLinkBuilder {
 
     /// Send the create query link request.
     pub async fn send(self) -> Result<String, ReductError> {
-        let mut request = self.request;
+        let mut request = self.request.clone();
+        let selected_index = self.selected_index;
+
         if self.entries.len() > 1 {
             if let Some(version) = self.http_client.get_api_version().await {
                 if version.1 < 18 {
                     return Err(ReductError::new(
-                        reduct_base::error::ErrorCode::InvalidRequest,
+                        ErrorCode::InvalidRequest,
                         "Multi-entry query links are not supported in API versions below v1.18",
                     ));
                 }
@@ -81,25 +105,173 @@ impl CreateQueryLinkBuilder {
             request.query.entries = Some(self.entries.clone());
         }
 
+        let record_identity = match selected_index {
+            Some(index) => Some(self.resolve_record_identity(&request, index).await?),
+            None => None,
+        };
+
+        let payload = QueryLinkCreateRequestCompat {
+            bucket: request.bucket.clone(),
+            entry: request.entry.clone(),
+            record_entry: record_identity.as_ref().map(|(entry, _)| entry.clone()),
+            record_timestamp: record_identity.map(|(_, timestamp)| timestamp),
+            index: selected_index,
+            query: request.query.clone(),
+            expire_at: request.expire_at,
+            base_url: request.base_url.clone(),
+        };
+
         let default_name = if self.entries.len() > 1 {
-            request.bucket.clone()
+            payload.bucket.clone()
         } else {
-            request.entry.clone()
+            payload.entry.clone()
         };
         let file_name = self.file_name.unwrap_or(format!(
             "{}_{}.bin",
             default_name,
-            request.index.unwrap_or(0)
+            payload.index.unwrap_or(0)
         ));
+
         let response: QueryLinkCreateResponse = self
             .http_client
             .send_and_receive_json(
                 Method::POST,
                 &format!("/links/{}", file_name),
-                Some(request),
+                Some(payload),
             )
             .await?;
+
         Ok(response.link)
+    }
+
+    async fn resolve_record_identity(
+        &self,
+        request: &QueryLinkCreateRequest,
+        index: u64,
+    ) -> Result<(String, u64), ReductError> {
+        let mut query = request.query.clone();
+        query.query_type = QueryType::Query;
+        query.only_metadata = Some(true);
+
+        let max_records = index.checked_add(1).ok_or_else(|| {
+            ReductError::new(ErrorCode::InvalidRequest, "Record index is too large")
+        })?;
+        query.limit = Some(query.limit.unwrap_or(max_records).min(max_records));
+
+        if self.entries.len() == 1 {
+            self.resolve_record_identity_v1(request, query, index).await
+        } else {
+            self.resolve_record_identity_v2(request, query, index).await
+        }
+    }
+
+    async fn resolve_record_identity_v1(
+        &self,
+        request: &QueryLinkCreateRequest,
+        query: QueryEntry,
+        index: u64,
+    ) -> Result<(String, u64), ReductError> {
+        let entry = request.entry.clone();
+        let query_info: QueryInfo = self
+            .http_client
+            .send_and_receive_json(
+                Method::POST,
+                &format!("/b/{}/{}/q", request.bucket, entry),
+                Some(query),
+            )
+            .await?;
+
+        let mut remaining = index;
+        loop {
+            let response = self
+                .http_client
+                .send_request(self.http_client.request(
+                    Method::HEAD,
+                    &format!("/b/{}/{}/batch?q={}", request.bucket, entry, query_info.id),
+                ))
+                .await?;
+
+            if response.status() == reqwest::StatusCode::NO_CONTENT {
+                break;
+            }
+
+            let is_last = response
+                .headers()
+                .get("x-reduct-last")
+                .and_then(|value| value.to_str().ok())
+                == Some("true");
+
+            for (timestamp, _) in sort_headers_by_time(response.headers())? {
+                if remaining == 0 {
+                    return Ok((entry, timestamp));
+                }
+                remaining -= 1;
+            }
+
+            if is_last {
+                break;
+            }
+        }
+
+        Err(ReductError::new(
+            ErrorCode::UnprocessableEntity,
+            "Record number out of range",
+        ))
+    }
+
+    async fn resolve_record_identity_v2(
+        &self,
+        request: &QueryLinkCreateRequest,
+        mut query: QueryEntry,
+        index: u64,
+    ) -> Result<(String, u64), ReductError> {
+        query.entries = Some(self.entries.clone());
+        let query_info: QueryInfo = self
+            .http_client
+            .send_and_receive_json(
+                Method::POST,
+                &format!("/io/{}/q", request.bucket),
+                Some(query),
+            )
+            .await?;
+
+        let mut remaining = index;
+        loop {
+            let response = self
+                .http_client
+                .send_request(
+                    self.http_client
+                        .request(Method::HEAD, &format!("/io/{}/read", request.bucket))
+                        .header("x-reduct-query-id", query_info.id.to_string()),
+                )
+                .await?;
+
+            if response.status() == reqwest::StatusCode::NO_CONTENT {
+                break;
+            }
+
+            let is_last = response
+                .headers()
+                .get("x-reduct-last")
+                .and_then(|value| value.to_str().ok())
+                == Some("true");
+
+            for record in parse_batched_headers(response.headers())? {
+                if remaining == 0 {
+                    return Ok((record.entry, record.timestamp));
+                }
+                remaining -= 1;
+            }
+
+            if is_last {
+                break;
+            }
+        }
+
+        Err(ReductError::new(
+            ErrorCode::UnprocessableEntity,
+            "Record number out of range",
+        ))
     }
 }
 
@@ -129,6 +301,7 @@ impl Bucket {
 mod tests {
     use crate::bucket::tests::bucket;
     use crate::Bucket;
+    use reduct_base::error::ErrorCode;
     use reduct_base::msg::entry_api::QueryEntry;
     use rstest::rstest;
 
@@ -189,12 +362,27 @@ mod tests {
         let bucket: Bucket = bucket.await;
         let link = bucket
             .create_query_link("entry-1")
-            .index(1)
+            .index(0)
             .send()
             .await
             .unwrap();
         let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
-        assert_eq!(body, r#"{"detail": "Record number out of range"}"#)
+        assert_eq!(body, "Hey entry-1!");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_link_creation_with_index_out_of_range(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        let err = bucket
+            .create_query_link("entry-1")
+            .index(1)
+            .send()
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.status(), ErrorCode::UnprocessableEntity);
+        assert_eq!(err.message(), "Record number out of range");
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #76

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature / compatibility update.

### What was changed?

- Updated query-link creation to resolve `index` selectors into explicit record identity (`record_entry` + `record_timestamp`) before creating the share link.
- Preserved legacy `index` in the link-create payload for compatibility with older server behavior.
- Added version-aware metadata lookup paths for both single-entry (`/b/{bucket}/{entry}/q` + batch HEAD) and multi-entry (`/io/{bucket}/q` + read HEAD) query flows.
- Improved index error handling to return `UnprocessableEntity` with `Record number out of range` when no record exists at the requested index.
- Updated `CHANGELOG.md` with the issue entry.

### Related issues

- https://github.com/reductstore/reduct-rs/issues/76
- https://github.com/reductstore/reduct-js/pull/167
- https://github.com/reductstore/reductstore/issues/1332

### Does this PR introduce a breaking change?

No. The existing `index` API remains supported; this change aligns payload semantics with the newer record identity API while keeping backward compatibility.

### Other information:

Validation run:

- `cargo fmt --all`
- `cargo check`
- `RS_API_TOKEN=TOKEN cargo test bucket::link::tests:: -- --test-threads=1` (against `reduct/store:latest`)
- `RS_API_TOKEN=TOKEN cargo test bucket::link::tests:: -- --test-threads=1` (against `reduct/store:main`)
