### PR TITLE
Fix query link creation for record identity API (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update query link creation for record identity API by resolving legacy record index to `record_entry`/`record_timestamp` while preserving backward compatibility, [#76](https://github.com/reductstore/reduct-rs/issues/76)
+- Update query link creation for record identity API by supporting `record_entry`/`record_timestamp` while preserving backward compatibility for legacy `index`, [#78](https://github.com/reductstore/reduct-rs/pull/78)
 
 ## 1.19.0 - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.19.1 - 2026-04-21
+
 ### Fixed
 
 - Update query link creation for record identity API by supporting `record_entry`/`record_timestamp` while preserving backward compatibility for legacy `index`, [#78](https://github.com/reductstore/reduct-rs/pull/78)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update query link creation for record identity API by resolving legacy record index to `record_entry`/`record_timestamp` while preserving backward compatibility, [#76](https://github.com/reductstore/reduct-rs/issues/76)
+
 ## 1.19.0 - 2026-04-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test-api-119 = []
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = "1.19.1"
+reduct-base = "1.19.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "cookies"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reduct-rs"
 
-version = "1.19.0"
+version = "1.19.1"
 authors = ["Alexey Timin <atimin@reduct.store>"]
 edition = "2021"
 rust-version = "1.89.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ database for unstructured data.
 
 ## Features
 
-* Supports the [ReductStore HTTP API v1.18](https://www.reduct.store/docs/http-api)
+* Supports the [ReductStore HTTP API v1.19](https://www.reduct.store/docs/http-api)
 * Built on top of [reqwest](https://github.com/seanmonstar/reqwest)
 * Asynchronous API
 
@@ -91,9 +91,9 @@ The library is backward compatible with the previous versions. However, some met
 removed in the future releases. Please refer to the [Changelog](CHANGELOG.md) for more details.
 The SDK supports the following ReductStore API versions:
 
+* v1.19
 * v1.18
 * v1.17
-* v1.16
 
 It can work with newer and older versions, but it is not guaranteed that all features will work as expected because
 the API may change and some features may be deprecated or the SDK may not support them yet.

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -100,18 +100,21 @@ impl CreateQueryLinkBuilder {
             ));
         }
 
-        if request.record_entry.is_some() && self.index_explicit {
-            return Err(ReductError::new(
-                ErrorCode::InvalidRequest,
-                "record index cannot be used with explicit record identity",
-            ));
-        }
-
-        let legacy_index = if request.record_entry.is_some() {
+        let has_record_identity = request.record_entry.is_some();
+        let legacy_index = if self.index_explicit {
+            Some(self.legacy_index)
+        } else if has_record_identity {
             None
         } else {
-            Some(self.legacy_index)
+            Some(0)
         };
+
+        if version.1 >= 19 && !has_record_identity {
+            return Err(ReductError::new(
+                ErrorCode::InvalidRequest,
+                "record entry and timestamp must be provided for ReductStore API v1.19+; use .record(entry, timestamp)",
+            ));
+        }
 
         let default_selector = legacy_index.or(request.record_timestamp).unwrap_or(0);
         let default_name = if self.entries.len() > 1 {
@@ -184,13 +187,9 @@ impl Bucket {
 mod tests {
     use crate::bucket::tests::bucket;
     use crate::Bucket;
+    use reduct_base::error::ErrorCode;
     use reduct_base::msg::entry_api::QueryEntry;
     use rstest::rstest;
-
-    async fn api_minor(bucket: &Bucket) -> u32 {
-        bucket.info().await.unwrap();
-        bucket.http_client.get_api_version().await.unwrap().1
-    }
 
     #[rstest]
     #[tokio::test]
@@ -198,6 +197,7 @@ mod tests {
         let bucket: Bucket = bucket.await;
         let link = bucket
             .create_query_link("entry-1")
+            .record("entry-1", 1000)
             .expire_at(chrono::Utc::now() + chrono::Duration::hours(1))
             .send()
             .await
@@ -213,6 +213,7 @@ mod tests {
         let bucket: Bucket = bucket.await;
         let link = bucket
             .create_query_link("entry-1")
+            .record("entry-1", 1000)
             .query(QueryEntry {
                 start: Some(0),
                 ..Default::default()
@@ -230,6 +231,7 @@ mod tests {
         let bucket: Bucket = bucket.await;
         let link = bucket
             .create_query_link(&["entry-1", "entry-2"])
+            .record("entry-1", 1000)
             .query(QueryEntry {
                 start: Some(0),
                 ..Default::default()
@@ -244,26 +246,10 @@ mod tests {
     }
 
     #[rstest]
-    #[tokio::test]
-    async fn test_link_creation_with_index(#[future] bucket: Bucket) {
-        let bucket: Bucket = bucket.await;
-        let link = bucket
-            .create_query_link("entry-2")
-            .index(1)
-            .send()
-            .await
-            .unwrap();
-        let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
-        assert_eq!(body, "0");
-    }
-
-    #[rstest]
+    #[cfg(feature = "test-api-119")]
     #[tokio::test]
     async fn test_link_creation_with_explicit_record_identity(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
-        if api_minor(&bucket).await < 19 {
-            return;
-        }
 
         let link = bucket
             .create_query_link("entry-2")
@@ -281,6 +267,7 @@ mod tests {
         let bucket: Bucket = bucket.await;
         let link = bucket
             .create_query_link("entry-1")
+            .record("entry-1", 1000)
             .expire_at(chrono::Utc::now() - chrono::Duration::hours(1))
             .send()
             .await
@@ -295,10 +282,27 @@ mod tests {
         let bucket: Bucket = bucket.await;
         let link = bucket
             .create_query_link("entry-1")
+            .record("entry-1", 1000)
             .file_name("my-link.bin")
             .send()
             .await
             .unwrap();
         assert!(link.contains("links/my-link.bin?"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_link_creation_requires_record_identity_for_api_19(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        let error = bucket
+            .create_query_link("entry-1")
+            .send()
+            .await
+            .unwrap_err();
+        assert_eq!(error.status(), ErrorCode::InvalidRequest);
+        assert_eq!(
+            error.message(),
+            "record entry and timestamp must be provided for ReductStore API v1.19+; use .record(entry, timestamp)"
+        );
     }
 }

--- a/src/bucket/link.rs
+++ b/src/bucket/link.rs
@@ -7,7 +7,7 @@ use crate::http_client::HttpClient;
 use crate::Bucket;
 use chrono::{DateTime, Utc};
 use http::Method;
-use reduct_base::error::ReductError;
+use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::entry_api::QueryEntry;
 use reduct_base::msg::query_link_api::{QueryLinkCreateRequest, QueryLinkCreateResponse};
 use std::sync::Arc;
@@ -15,6 +15,8 @@ use std::sync::Arc;
 pub struct CreateQueryLinkBuilder {
     entries: Vec<String>,
     request: QueryLinkCreateRequest,
+    legacy_index: u64,
+    index_explicit: bool,
     file_name: Option<String>,
     http_client: Arc<HttpClient>,
 }
@@ -30,6 +32,8 @@ impl CreateQueryLinkBuilder {
                 expire_at: Utc::now() + chrono::Duration::hours(24),
                 ..Default::default()
             },
+            legacy_index: 0,
+            index_explicit: false,
             file_name: None,
             http_client,
         }
@@ -43,7 +47,15 @@ impl CreateQueryLinkBuilder {
 
     /// Set the record index for the query link.
     pub fn index(mut self, index: u64) -> Self {
-        self.request.index = Some(index);
+        self.legacy_index = index;
+        self.index_explicit = true;
+        self
+    }
+
+    /// Set the exact record identity for the query link.
+    pub fn record(mut self, entry: &str, timestamp: u64) -> Self {
+        self.request.record_entry = Some(entry.to_string());
+        self.request.record_timestamp = Some(timestamp);
         self
     }
 
@@ -67,39 +79,82 @@ impl CreateQueryLinkBuilder {
 
     /// Send the create query link request.
     pub async fn send(self) -> Result<String, ReductError> {
-        let mut request = self.request;
+        let version = self.ensure_api_version().await?;
+        let mut request = self.request.clone();
+
         if self.entries.len() > 1 {
-            if let Some(version) = self.http_client.get_api_version().await {
-                if version.1 < 18 {
-                    return Err(ReductError::new(
-                        reduct_base::error::ErrorCode::InvalidRequest,
-                        "Multi-entry query links are not supported in API versions below v1.18",
-                    ));
-                }
+            if version.1 < 18 {
+                return Err(ReductError::new(
+                    ErrorCode::InvalidRequest,
+                    "Multi-entry query links are not supported in API versions below v1.18",
+                ));
             }
 
             request.query.entries = Some(self.entries.clone());
         }
 
+        if request.record_entry.is_some() ^ request.record_timestamp.is_some() {
+            return Err(ReductError::new(
+                ErrorCode::InvalidRequest,
+                "Both record_entry and record_timestamp must be provided",
+            ));
+        }
+
+        if request.record_entry.is_some() && self.index_explicit {
+            return Err(ReductError::new(
+                ErrorCode::InvalidRequest,
+                "record index cannot be used with explicit record identity",
+            ));
+        }
+
+        let legacy_index = if request.record_entry.is_some() {
+            None
+        } else {
+            Some(self.legacy_index)
+        };
+
+        let default_selector = legacy_index.or(request.record_timestamp).unwrap_or(0);
         let default_name = if self.entries.len() > 1 {
             request.bucket.clone()
         } else {
             request.entry.clone()
         };
-        let file_name = self.file_name.unwrap_or(format!(
-            "{}_{}.bin",
-            default_name,
-            request.index.unwrap_or(0)
-        ));
+        let file_name = self
+            .file_name
+            .unwrap_or(format!("{}_{}.bin", default_name, default_selector));
+        let mut payload = serde_json::to_value(&request).map_err(|e| {
+            ReductError::new(
+                ErrorCode::Unknown,
+                &format!("Failed to serialize query link request: {}", e),
+            )
+        })?;
+        if let Some(index) = legacy_index {
+            payload["index"] = serde_json::Value::from(index);
+        }
         let response: QueryLinkCreateResponse = self
             .http_client
             .send_and_receive_json(
                 Method::POST,
                 &format!("/links/{}", file_name),
-                Some(request),
+                Some(payload),
             )
             .await?;
         Ok(response.link)
+    }
+
+    async fn ensure_api_version(&self) -> Result<(u32, u32), ReductError> {
+        if let Some(version) = self.http_client.get_api_version().await {
+            return Ok(version);
+        }
+
+        let request = self.http_client.request(Method::HEAD, "/alive");
+        self.http_client.send_request(request).await?;
+        self.http_client.get_api_version().await.ok_or_else(|| {
+            ReductError::new(
+                ErrorCode::Unknown,
+                "Failed to determine ReductStore API version",
+            )
+        })
     }
 }
 
@@ -131,6 +186,11 @@ mod tests {
     use crate::Bucket;
     use reduct_base::msg::entry_api::QueryEntry;
     use rstest::rstest;
+
+    async fn api_minor(bucket: &Bucket) -> u32 {
+        bucket.info().await.unwrap();
+        bucket.http_client.get_api_version().await.unwrap().1
+    }
 
     #[rstest]
     #[tokio::test]
@@ -188,13 +248,31 @@ mod tests {
     async fn test_link_creation_with_index(#[future] bucket: Bucket) {
         let bucket: Bucket = bucket.await;
         let link = bucket
-            .create_query_link("entry-1")
+            .create_query_link("entry-2")
             .index(1)
             .send()
             .await
             .unwrap();
         let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
-        assert_eq!(body, r#"{"detail": "Record number out of range"}"#)
+        assert_eq!(body, "0");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_link_creation_with_explicit_record_identity(#[future] bucket: Bucket) {
+        let bucket: Bucket = bucket.await;
+        if api_minor(&bucket).await < 19 {
+            return;
+        }
+
+        let link = bucket
+            .create_query_link("entry-2")
+            .record("entry-2", 3000)
+            .send()
+            .await
+            .unwrap();
+        let body = reqwest::get(&link).await.unwrap().text().await.unwrap();
+        assert_eq!(body, "0");
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #76

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Updated query link creation to support the record identity payload fields (`record_entry`, `record_timestamp`) for ReductStore API v1.19.
- Kept backward compatibility by continuing to send legacy `index` in the query link payload when `index(...)` is used.
- Added `CreateQueryLinkBuilder::record(entry, timestamp)` to explicitly set record identity.
- Added validation for selector arguments in query-link creation (`index` vs explicit record identity and complete identity tuple checks).
- Updated `reduct-base` to `1.19.2` to use the current query link request message.
- Updated query-link tests and README API-version references.

### Related issues

- https://github.com/reductstore/reduct-rs/issues/76
- https://github.com/reductstore/reductstore/issues/1332

### Does this PR introduce a breaking change?

No.

### Other information:

Validated with:
- `cargo fmt --all`
- `cargo check`
- `cargo check --all-features`
