### PR TITLE
Harden CI GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
       - README.md
       - CHANGELOG.md
 
+permissions: read-all
+
 env:
   REGISTRY_IMAGE: reduct/store
   MINIMAL_RUST_VERSION: ${{ vars.MINIMAL_RUST_VERSION }}


### PR DESCRIPTION
Closes #79

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI configuration update.

### What was changed?

- Added workflow-level `permissions: read-all` in `.github/workflows/ci.yml`.
- Kept elevated token permissions unset because this workflow currently has no jobs that require write scopes or OIDC.
- This enforces least-privilege defaults for `GITHUB_TOKEN` across CI jobs.

Implementation plan reference: https://github.com/reductstore/reduct-rs/issues/79#issuecomment-4311795136

### Related issues

- https://github.com/reductstore/reduct-rs/issues/79
- Parent tracking: https://github.com/reductstore/security/issues/16

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:
- `cargo fmt --all`
- `cargo check`
