### PR TITLE
Pin third-party GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Rust Linter
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check code
         run: cargo fmt --all -- --check
 
@@ -46,7 +46,7 @@ jobs:
     needs:
       - rust_fmt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Generate license
         run: echo '${{secrets.LICENSE_KEY}}' > lic.key
       - name: Run Database
@@ -86,7 +86,7 @@ jobs:
       matrix:
         example: [ "hallo_world", "query" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run Database
         run: docker run --network=host -v ${PWD}/misc:/misc -d ${{env.REGISTRY_IMAGE}}
       - name: Run Client SDK tests
@@ -99,7 +99,7 @@ jobs:
     needs:
       - rust_fmt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check tag
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -131,7 +131,7 @@ jobs:
       - dry_publish
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           --env RS_LICENSE_PATH=/misc/lic.key -d reduct/store:${{ matrix.reductstore_version }}
 
       - name: Use cache for Cargo
-        uses: runs-on/cache@v4
+        uses: runs-on/cache@bd330c5a5f6cbb837823ee25864f3c71a211c2e3 # v5.0.5
         with:
           path: |
             ~/.cargo/bin/
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ env.MINIMAL_RUST_VERSION }}
       - name: Dry run publish reduct-rs
@@ -133,10 +133,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: ${{ env.MINIMAL_RUST_VERSION }}
-      - uses: arduino/setup-protoc@v1
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           version: '3.x'
           repo-token: ${{ secrets.ACTION_GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support non-JSON content types in `write_attachments` and `read_attachments`, [PR-83](https://github.com/reductstore/reduct-rs/pull/83)
 
+### Changed
+
+- Pin third-party GitHub Actions in CI workflows by commit SHA (`runs-on/cache`, `dtolnay/rust-toolchain`, `arduino/setup-protoc`), [PR-84](https://github.com/reductstore/reduct-rs/pull/84)
+
 ## 1.19.1 - 2026-04-21
 
 ### Fixed


### PR DESCRIPTION
Closes #81

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI maintenance.

### What was changed?

Pinned third-party GitHub Actions in `.github/workflows/ci.yml` to immutable commit SHAs and updated them to current stable release lines where applicable:

- `runs-on/cache@v4` → `runs-on/cache@bd330c5a5f6cbb837823ee25864f3c71a211c2e3` (`v5.0.5`)
- `dtolnay/rust-toolchain@stable` → `dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9` (`v1`) in both publish jobs
- `arduino/setup-protoc@v1` → `arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b` (`v3.0.0`)

First-party `actions/*` references were left unchanged.

### Related issues

- https://github.com/reductstore/reduct-rs/issues/81
- Parent tracking issue: https://github.com/reductstore/security/issues/22
- Approved implementation plan: https://github.com/reductstore/reduct-rs/issues/81#issuecomment-4379783312

### Does this PR introduce a breaking change?

No API/runtime breaking changes. CI action behavior changes are covered by normal PR CI validation.

### Other information:

Validation run locally:

- `cargo fmt --all`
- `cargo check`
