### PR TITLE
Align lifecycle SDK with older_than and compress action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add lifecycle `compress` action support and rename lifecycle age field from `max_age` to `older_than` to match the ReductStore API, [PR-87](https://github.com/reductstore/reduct-rs/pull/87)
+- Add lifecycle `compress` action support and rename lifecycle age field from `max_age` to `older_than` to match the ReductStore API, [PR-88](https://github.com/reductstore/reduct-rs/pull/88)
 - Add lifecycle policy API support, [PR-86](https://github.com/reductstore/reduct-rs/pull/86)
 - Pin third-party GitHub Actions in CI workflows by commit SHA (`runs-on/cache`, `dtolnay/rust-toolchain`, `arduino/setup-protoc`), [PR-84](https://github.com/reductstore/reduct-rs/pull/84)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add lifecycle `compress` action support and rename lifecycle age field from `max_age` to `older_than` to match the ReductStore API, [PR-87](https://github.com/reductstore/reduct-rs/pull/87)
 - Add lifecycle policy API support, [PR-86](https://github.com/reductstore/reduct-rs/pull/86)
 - Pin third-party GitHub Actions in CI workflows by commit SHA (`runs-on/cache`, `dtolnay/rust-toolchain`, `arduino/setup-protoc`), [PR-84](https://github.com/reductstore/reduct-rs/pull/84)
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -54,13 +54,13 @@ impl LifecycleBuilder {
         self
     }
 
-    /// Set the maximum record age.
+    /// Set the record age threshold.
     ///
     /// # Arguments
     ///
-    /// * `max_age` - Maximum age, e.g. "30d", "24h", or "3600s".
-    pub fn max_age(mut self, max_age: &str) -> Self {
-        self.settings.max_age = max_age.to_string();
+    /// * `older_than` - Age threshold, e.g. "30d", "24h", or "3600s".
+    pub fn older_than(mut self, older_than: &str) -> Self {
+        self.settings.older_than = older_than.to_string();
         self
     }
 
@@ -176,7 +176,7 @@ impl ReductClient {
     ///         .lifecycle_type(LifecycleType::Delete)
     ///         .bucket("test-bucket-1")
     ///         .entries(vec!["entry-*".to_string()])
-    ///         .max_age("1h")
+    ///         .older_than("1h")
     ///         .interval("10m")
     ///         .when(condition!({"$eq": ["&label", 1]}))
     ///         .mode(LifecycleMode::DryRun)
@@ -305,7 +305,7 @@ mod tests {
             .await
             .unwrap();
 
-        settings.max_age = "2h".to_string();
+        settings.older_than = "2h".to_string();
         settings.mode = LifecycleMode::Disabled;
 
         client
@@ -382,10 +382,10 @@ mod tests {
     #[fixture]
     fn settings() -> LifecycleSettings {
         LifecycleSettings {
-            lifecycle_type: LifecycleType::Delete,
+            lifecycle_type: LifecycleType::Compress,
             bucket: "test-bucket-1".to_string(),
             entries: vec![],
-            max_age: "1h".to_string(),
+            older_than: "1h".to_string(),
             interval: "10m".to_string(),
             when: Some(condition!({"$eq": ["&label", 1]})),
             mode: LifecycleMode::Enabled,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -262,7 +262,7 @@ mod tests {
             .lifecycle_type(settings.lifecycle_type)
             .bucket(settings.bucket.as_str())
             .entries(settings.entries.clone())
-            .max_age(settings.max_age.as_str())
+            .older_than(settings.older_than.as_str())
             .interval(settings.interval.as_str())
             .when(settings.when.unwrap())
             .mode(settings.mode)

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -382,7 +382,7 @@ mod tests {
     #[fixture]
     fn settings() -> LifecycleSettings {
         LifecycleSettings {
-            lifecycle_type: LifecycleType::Compress,
+            lifecycle_type: LifecycleType::Delete,
             bucket: "test-bucket-1".to_string(),
             entries: vec![],
             older_than: "1h".to_string(),

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -259,7 +259,7 @@ mod tests {
         let client = client.await;
         client
             .create_lifecycle("test-lifecycle")
-            .lifecycle_type(settings.lifecycle_type)
+            .lifecycle_type(LifecycleType::Compress)
             .bucket(settings.bucket.as_str())
             .entries(settings.entries.clone())
             .older_than(settings.older_than.as_str())

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -264,7 +264,6 @@ mod tests {
             .entries(settings.entries.clone())
             .older_than(settings.older_than.as_str())
             .interval(settings.interval.as_str())
-            .when(settings.when.unwrap())
             .mode(settings.mode)
             .send()
             .await


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature update

### What was changed?

- rename the lifecycle builder/settings age field from `max_age` to `older_than`
- update lifecycle examples/tests to use `older_than`
- switch lifecycle test settings to the new `compress` action
- update changelog

### Related issues

- https://github.com/reductstore/reductstore/pull/1427
- https://github.com/reductstore/reductstore/pull/1429

### Does this PR introduce a breaking change?

Yes. The lifecycle API is still unreleased in this SDK, so it now uses `older_than` instead of `max_age` before release.

### Other information:

- `cargo check` passes locally against the updated `reduct-base` from `reductstore/reductstore` main.
- `cargo test --lib` still expects a local ReductStore test server on `127.0.0.1:8383`, so integration-style tests cannot complete here without it.
