### PR TITLE
Support lifecycle info type and datetime last_run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Support lifecycle info `type` and datetime `last_run` fields from the updated ReductStore API, [PR-89](https://github.com/reductstore/reduct-rs/pull/89)
 - Add lifecycle `compress` action support and rename lifecycle age field from `max_age` to `older_than` to match the ReductStore API, [PR-88](https://github.com/reductstore/reduct-rs/pull/88)
 - Add lifecycle policy API support, [PR-86](https://github.com/reductstore/reduct-rs/pull/86)
 - Pin third-party GitHub Actions in CI workflows by commit SHA (`runs-on/cache`, `dtolnay/rust-toolchain`, `arduino/setup-protoc`), [PR-84](https://github.com/reductstore/reduct-rs/pull/84)

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -8,6 +8,88 @@ use reqwest::Method;
 use serde_json::Value;
 use std::sync::Arc;
 
+#[cfg(test)]
+mod serde_tests {
+    use crate::{
+        FullLifecycleInfo, LifecycleInfo, LifecycleMode, LifecycleSettings, LifecycleType,
+    };
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn lifecycle_info_deserializes_type_and_last_run() {
+        let info: LifecycleInfo = serde_json::from_str(
+            r#"{
+                "name": "test-lifecycle",
+                "is_provisioned": true,
+                "is_running": false,
+                "type": "compress",
+                "mode": "enabled",
+                "last_run": "2026-06-15T07:02:25Z"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(info.lifecycle_type, LifecycleType::Compress);
+        assert_eq!(info.mode, LifecycleMode::Enabled);
+        assert_eq!(
+            info.last_run,
+            Some(
+                Utc.with_ymd_and_hms(2026, 6, 15, 7, 2, 25)
+                    .single()
+                    .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn full_lifecycle_info_deserializes_with_datetime_last_run() {
+        let lifecycle: FullLifecycleInfo = serde_json::from_str(
+            r#"{
+                "info": {
+                    "name": "test-lifecycle",
+                    "is_provisioned": true,
+                    "is_running": false,
+                    "type": "delete",
+                    "mode": "dry_run",
+                    "last_run": "2026-06-15T07:02:25Z"
+                },
+                "settings": {
+                    "type": "delete",
+                    "bucket": "test-bucket",
+                    "entries": ["entry-*"],
+                    "older_than": "1h",
+                    "interval": "10m",
+                    "mode": "dry_run"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(lifecycle.info.lifecycle_type, LifecycleType::Delete);
+        assert_eq!(lifecycle.info.mode, LifecycleMode::DryRun);
+        assert_eq!(
+            lifecycle.info.last_run,
+            Some(
+                Utc.with_ymd_and_hms(2026, 6, 15, 7, 2, 25)
+                    .single()
+                    .unwrap()
+            )
+        );
+        assert_eq!(
+            lifecycle.settings,
+            LifecycleSettings {
+                lifecycle_type: LifecycleType::Delete,
+                bucket: "test-bucket".to_string(),
+                entries: vec!["entry-*".to_string()],
+                older_than: "1h".to_string(),
+                interval: "10m".to_string(),
+                when: None,
+                mode: LifecycleMode::DryRun,
+            }
+        );
+    }
+}
+
 /// Lifecycle builder.
 pub struct LifecycleBuilder {
     name: String,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -8,88 +8,6 @@ use reqwest::Method;
 use serde_json::Value;
 use std::sync::Arc;
 
-#[cfg(test)]
-mod serde_tests {
-    use crate::{
-        FullLifecycleInfo, LifecycleInfo, LifecycleMode, LifecycleSettings, LifecycleType,
-    };
-    use chrono::{TimeZone, Utc};
-
-    #[test]
-    fn lifecycle_info_deserializes_type_and_last_run() {
-        let info: LifecycleInfo = serde_json::from_str(
-            r#"{
-                "name": "test-lifecycle",
-                "is_provisioned": true,
-                "is_running": false,
-                "type": "compress",
-                "mode": "enabled",
-                "last_run": "2026-06-15T07:02:25Z"
-            }"#,
-        )
-        .unwrap();
-
-        assert_eq!(info.lifecycle_type, LifecycleType::Compress);
-        assert_eq!(info.mode, LifecycleMode::Enabled);
-        assert_eq!(
-            info.last_run,
-            Some(
-                Utc.with_ymd_and_hms(2026, 6, 15, 7, 2, 25)
-                    .single()
-                    .unwrap()
-            )
-        );
-    }
-
-    #[test]
-    fn full_lifecycle_info_deserializes_with_datetime_last_run() {
-        let lifecycle: FullLifecycleInfo = serde_json::from_str(
-            r#"{
-                "info": {
-                    "name": "test-lifecycle",
-                    "is_provisioned": true,
-                    "is_running": false,
-                    "type": "delete",
-                    "mode": "dry_run",
-                    "last_run": "2026-06-15T07:02:25Z"
-                },
-                "settings": {
-                    "type": "delete",
-                    "bucket": "test-bucket",
-                    "entries": ["entry-*"],
-                    "older_than": "1h",
-                    "interval": "10m",
-                    "mode": "dry_run"
-                }
-            }"#,
-        )
-        .unwrap();
-
-        assert_eq!(lifecycle.info.lifecycle_type, LifecycleType::Delete);
-        assert_eq!(lifecycle.info.mode, LifecycleMode::DryRun);
-        assert_eq!(
-            lifecycle.info.last_run,
-            Some(
-                Utc.with_ymd_and_hms(2026, 6, 15, 7, 2, 25)
-                    .single()
-                    .unwrap()
-            )
-        );
-        assert_eq!(
-            lifecycle.settings,
-            LifecycleSettings {
-                lifecycle_type: LifecycleType::Delete,
-                bucket: "test-bucket".to_string(),
-                entries: vec!["entry-*".to_string()],
-                older_than: "1h".to_string(),
-                interval: "10m".to_string(),
-                when: None,
-                mode: LifecycleMode::DryRun,
-            }
-        );
-    }
-}
-
 /// Lifecycle builder.
 pub struct LifecycleBuilder {
     name: String,
@@ -359,6 +277,9 @@ mod tests {
             .unwrap();
         let lifecycles = test_lifecycles(client.list_lifecycles().await.unwrap());
         assert_eq!(lifecycles.len(), 1);
+        assert_eq!(lifecycles[0].lifecycle_type, LifecycleType::Compress);
+        assert_eq!(lifecycles[0].mode, settings.mode);
+        assert!(lifecycles[0].last_run.is_none());
     }
 
     #[rstest]
@@ -375,7 +296,9 @@ mod tests {
         let lifecycle = client.get_lifecycle("test-lifecycle").await.unwrap();
 
         assert_eq!(lifecycle.info.name, "test-lifecycle");
+        assert_eq!(lifecycle.info.lifecycle_type, settings.lifecycle_type);
         assert_eq!(lifecycle.info.mode, settings.mode);
+        assert!(lifecycle.info.last_run.is_none());
         assert_eq!(lifecycle.settings, settings);
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -328,10 +328,17 @@ mod tests {
     use crate::condition;
     use rstest::{fixture, rstest};
 
+    fn test_lifecycles(lifecycles: Vec<LifecycleInfo>) -> Vec<LifecycleInfo> {
+        lifecycles
+            .into_iter()
+            .filter(|lifecycle| lifecycle.name.starts_with("test-lifecycle"))
+            .collect()
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_list_lifecycles(#[future] client: ReductClient) {
-        let lifecycles = client.await.list_lifecycles().await.unwrap();
+        let lifecycles = test_lifecycles(client.await.list_lifecycles().await.unwrap());
         assert!(lifecycles.is_empty());
     }
 
@@ -350,7 +357,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        let lifecycles = client.list_lifecycles().await.unwrap();
+        let lifecycles = test_lifecycles(client.list_lifecycles().await.unwrap());
         assert_eq!(lifecycles.len(), 1);
     }
 
@@ -456,7 +463,7 @@ mod tests {
 
         client.delete_lifecycle("test-lifecycle").await.unwrap();
 
-        let lifecycles = client.list_lifecycles().await.unwrap();
+        let lifecycles = test_lifecycles(client.list_lifecycles().await.unwrap());
         assert!(lifecycles.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- verify the SDK accepts lifecycle info payloads with the new `type` field
- verify `last_run` is handled as `DateTime<Utc>` / RFC3339 rather than a raw integer
- keep the change minimal by relying on the updated `reduct-base` lifecycle types already re-exported by the SDK

## Testing
- cargo test serde_tests --lib
- cargo test --lib *(fails in this environment because the integration-style tests expect a ReductStore server on `127.0.0.1:8383`)*