### PR TITLE
Add replication destination prefix support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         reductstore_version: [ "main", "latest" ]
         include:
           - reductstore_version: main
-            features: "default,test-api-120"
+            features: "default,test-api-121"
           - reductstore_version: latest
             features: "default"
     needs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,14 @@
 - Library entry is `src/lib.rs`; client surface is split into `client.rs`, `http_client.rs`, and feature modules under `src/bucket`, `src/record`, and `src/replication.rs`.
 - Examples demonstrating API usage live in `examples/hallo_world.rs` and `examples/query.rs`; use them as runnable docs.
 - Tests sit next to the code inside `mod tests` blocks and rely on async Tokio + `rstest`; there is no standalone `tests/` folder.
-- `Cargo.toml` pins Rust 1.89 (edition 2021) and defines the `test-api-120` feature used for compatibility checks against development API behavior.
+- `Cargo.toml` pins Rust 1.89 (edition 2021) and defines the `test-api-121` feature used for compatibility checks against development API behavior.
 
 ## Build, Test, and Development Commands
 - `cargo fmt --all` — required by CI; keep it clean before pushing.
 - `cargo check` — fast sanity compile (also wired in pre-commit).
 - `cargo build --release` — produce optimized artifacts.
 - Start ReductStore locally before tests: `docker run --rm --network host -e RS_API_TOKEN=TOKEN reduct/store:latest` (expects HTTP on `127.0.0.1:8383`).
-- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1` — main test suite; use `--features "default,test-api-120"` to exercise the backward-compat matrix (dev branch).
+- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1` — main test suite; use `--features "default,test-api-121"` to exercise the backward-compat matrix (dev branch).
 - `cargo run --example hallo_world` (or `query`) — run examples against the local server.
 
 ## Coding Style & Naming Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add replication destination prefix support, [PR-<NN>](https://github.com/reductstore/reduct-rs/pull/<NN>)
+
 ## 1.20.0 - 2026-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add replication destination prefix support, [PR-<NN>](https://github.com/reductstore/reduct-rs/pull/<NN>)
+- Add replication destination prefix support, [PR-94](https://github.com/reductstore/reduct-rs/pull/94)
 
 ## 1.20.0 - 2026-06-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["database"]
 
 [features]
 default = []
-test-api-120 = []
+test-api-121 = []
 
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test-api-120 = []
 crate-type = ["lib"]
 
 [dependencies]
-reduct-base = { version = "1.20.0" }
+reduct-base = { git = "https://github.com/reductstore/reductstore.git", branch = "main" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "cookies"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@
 
 use crate::bucket::BucketBuilder;
 use crate::http_client::HttpClient;
-use crate::replication::{ReplicationBuilder, ReplicationSettingsRequest};
+use crate::replication::ReplicationBuilder;
 use crate::Bucket;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::replication_api::{
@@ -342,11 +342,7 @@ impl ReductClient {
         settings: ReplicationSettings,
     ) -> Result<()> {
         self.http_client
-            .send_json(
-                Method::PUT,
-                &format!("/replications/{}", name),
-                ReplicationSettingsRequest::from(&settings),
-            )
+            .send_json(Method::PUT, &format!("/replications/{}", name), settings)
             .await
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -707,7 +707,7 @@ YyRIHN8wfdVoOw==
             }
         }
 
-        #[cfg(feature = "test-api-120")]
+        #[cfg(feature = "test-api-121")]
         #[rstest]
         #[tokio::test]
         async fn test_replication_dst_prefix(

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@
 
 use crate::bucket::BucketBuilder;
 use crate::http_client::HttpClient;
-use crate::replication::ReplicationBuilder;
+use crate::replication::{ReplicationBuilder, ReplicationSettingsRequest};
 use crate::Bucket;
 use reduct_base::error::{ErrorCode, ReductError};
 use reduct_base::msg::replication_api::{
@@ -342,7 +342,11 @@ impl ReductClient {
         settings: ReplicationSettings,
     ) -> Result<()> {
         self.http_client
-            .send_json(Method::PUT, &format!("/replications/{}", name), settings)
+            .send_json(
+                Method::PUT,
+                &format!("/replications/{}", name),
+                ReplicationSettingsRequest::from(&settings),
+            )
             .await
     }
 
@@ -580,6 +584,7 @@ YyRIHN8wfdVoOw==
                 .dst_host(settings.dst_host.as_str())
                 .dst_token(settings.dst_token.unwrap_or_default().as_str())
                 .entries(settings.entries.clone())
+                .dst_prefix(settings.dst_prefix.as_str())
                 .when(settings.when.unwrap())
                 .send()
                 .await
@@ -697,13 +702,48 @@ YyRIHN8wfdVoOw==
                 dst_host: "http://127.0.0.1:8383".to_string(),
                 dst_token: std::env::var("RS_API_TOKEN").ok(),
                 entries: vec![],
+                dst_prefix: String::new(),
                 include: Labels::default(),
                 exclude: Labels::default(),
-                each_s: Some(1.0),
                 each_n: Some(1),
                 when: Some(condition!({"$eq": ["&label", 1]})),
                 mode: ReplicationMode::Enabled,
             }
+        }
+
+        #[cfg(feature = "test-api-120")]
+        #[rstest]
+        #[tokio::test]
+        async fn test_replication_dst_prefix(
+            #[future] client: ReductClient,
+            mut settings: ReplicationSettings,
+        ) {
+            let client = client.await;
+            settings.dst_prefix = "robot-1".to_string();
+            client
+                .create_replication("test-replication-prefix")
+                .set_settings(settings.clone())
+                .send()
+                .await
+                .unwrap();
+
+            let replication = client
+                .get_replication("test-replication-prefix")
+                .await
+                .unwrap();
+            assert_eq!(replication.settings.dst_prefix, "robot-1");
+
+            settings.dst_prefix = "line-a".to_string();
+            client
+                .update_replication("test-replication-prefix", settings.clone())
+                .await
+                .unwrap();
+
+            let replication = client
+                .get_replication("test-replication-prefix")
+                .await
+                .unwrap();
+            assert_eq!(replication.settings.dst_prefix, "line-a");
         }
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -239,7 +239,7 @@ impl ReductClient {
     }
 }
 
-#[cfg(all(test, feature = "test-api-121"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::client::tests::client;

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -239,7 +239,7 @@ impl ReductClient {
     }
 }
 
-#[cfg(all(test, feature = "test-api-120"))]
+#[cfg(all(test, feature = "test-api-121"))]
 mod tests {
     use super::*;
     use crate::client::tests::client;

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -5,9 +5,12 @@
 
 use crate::client::Result;
 use crate::http_client::HttpClient;
+use crate::Labels;
 
 use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
 use reqwest::Method;
+use serde::Serialize;
+use serde_json::Value;
 use std::sync::Arc;
 
 /// Replication builder.
@@ -79,6 +82,16 @@ impl ReplicationBuilder {
         self
     }
 
+    /// Set the destination entry prefix.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix` - Prefix to add to destination entry names.
+    pub fn dst_prefix(mut self, prefix: &str) -> Self {
+        self.settings.dst_prefix = prefix.to_string();
+        self
+    }
+
     /// Set the replication conditional query.
     ///
     /// # Arguments
@@ -113,8 +126,76 @@ impl ReplicationBuilder {
             .send_json(
                 Method::POST,
                 &format!("/replications/{}", self.name),
-                self.settings,
+                ReplicationSettingsRequest::from(&self.settings),
             )
             .await
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct ReplicationSettingsRequest<'a> {
+    src_bucket: &'a str,
+    dst_bucket: &'a str,
+    dst_host: &'a str,
+    dst_token: &'a Option<String>,
+    entries: &'a Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dst_prefix: Option<&'a str>,
+    include: &'a Labels,
+    exclude: &'a Labels,
+    each_n: &'a Option<u64>,
+    when: &'a Option<Value>,
+    mode: ReplicationMode,
+}
+
+impl<'a> From<&'a ReplicationSettings> for ReplicationSettingsRequest<'a> {
+    fn from(settings: &'a ReplicationSettings) -> Self {
+        Self {
+            src_bucket: settings.src_bucket.as_str(),
+            dst_bucket: settings.dst_bucket.as_str(),
+            dst_host: settings.dst_host.as_str(),
+            dst_token: &settings.dst_token,
+            entries: &settings.entries,
+            dst_prefix: if settings.dst_prefix.is_empty() {
+                None
+            } else {
+                Some(settings.dst_prefix.as_str())
+            },
+            include: &settings.include,
+            exclude: &settings.exclude,
+            each_n: &settings.each_n,
+            when: &settings.when,
+            mode: settings.mode,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_replication_settings_request_omits_empty_dst_prefix() {
+        let settings = ReplicationSettings::default();
+
+        let value = serde_json::to_value(ReplicationSettingsRequest::from(&settings)).unwrap();
+
+        assert_eq!(value.get("dst_prefix"), None);
+    }
+
+    #[test]
+    fn test_replication_settings_request_serializes_dst_prefix() {
+        let settings = ReplicationSettings {
+            src_bucket: "edge".to_string(),
+            dst_bucket: "fleet".to_string(),
+            dst_host: "https://central.example".to_string(),
+            dst_prefix: "robot-1".to_string(),
+            ..Default::default()
+        };
+
+        let value = serde_json::to_value(ReplicationSettingsRequest::from(&settings)).unwrap();
+
+        assert_eq!(value["dst_prefix"], json!("robot-1"));
     }
 }

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -5,12 +5,9 @@
 
 use crate::client::Result;
 use crate::http_client::HttpClient;
-use crate::Labels;
 
 use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
 use reqwest::Method;
-use serde::Serialize;
-use serde_json::Value;
 use std::sync::Arc;
 
 /// Replication builder.
@@ -126,76 +123,8 @@ impl ReplicationBuilder {
             .send_json(
                 Method::POST,
                 &format!("/replications/{}", self.name),
-                ReplicationSettingsRequest::from(&self.settings),
+                self.settings,
             )
             .await
-    }
-}
-
-#[derive(Serialize)]
-pub(crate) struct ReplicationSettingsRequest<'a> {
-    src_bucket: &'a str,
-    dst_bucket: &'a str,
-    dst_host: &'a str,
-    dst_token: &'a Option<String>,
-    entries: &'a Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    dst_prefix: Option<&'a str>,
-    include: &'a Labels,
-    exclude: &'a Labels,
-    each_n: &'a Option<u64>,
-    when: &'a Option<Value>,
-    mode: ReplicationMode,
-}
-
-impl<'a> From<&'a ReplicationSettings> for ReplicationSettingsRequest<'a> {
-    fn from(settings: &'a ReplicationSettings) -> Self {
-        Self {
-            src_bucket: settings.src_bucket.as_str(),
-            dst_bucket: settings.dst_bucket.as_str(),
-            dst_host: settings.dst_host.as_str(),
-            dst_token: &settings.dst_token,
-            entries: &settings.entries,
-            dst_prefix: if settings.dst_prefix.is_empty() {
-                None
-            } else {
-                Some(settings.dst_prefix.as_str())
-            },
-            include: &settings.include,
-            exclude: &settings.exclude,
-            each_n: &settings.each_n,
-            when: &settings.when,
-            mode: settings.mode,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_replication_settings_request_omits_empty_dst_prefix() {
-        let settings = ReplicationSettings::default();
-
-        let value = serde_json::to_value(ReplicationSettingsRequest::from(&settings)).unwrap();
-
-        assert_eq!(value.get("dst_prefix"), None);
-    }
-
-    #[test]
-    fn test_replication_settings_request_serializes_dst_prefix() {
-        let settings = ReplicationSettings {
-            src_bucket: "edge".to_string(),
-            dst_bucket: "fleet".to_string(),
-            dst_host: "https://central.example".to_string(),
-            dst_prefix: "robot-1".to_string(),
-            ..Default::default()
-        };
-
-        let value = serde_json::to_value(ReplicationSettingsRequest::from(&settings)).unwrap();
-
-        assert_eq!(value["dst_prefix"], json!("robot-1"));
     }
 }


### PR DESCRIPTION
Closes #93

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Use `reduct-base` from `reductstore/main`, as requested in the approved issue thread, so the SDK can consume the new replication `dst_prefix` model field.
- Add `ReplicationBuilder::dst_prefix(...)` for create flows while keeping `set_settings(ReplicationSettings)` and `update_replication(...)` available for direct model usage.
- Send create/update replication payloads using the `reduct-base` `ReplicationSettings` model directly, per review feedback.
- Add a `test-api-121` integration regression that creates, reads, updates, and reads back a replication prefix against `reduct/store:main`.

Implementation follows the approved plan:
https://github.com/reductstore/reduct-rs/issues/93#issuecomment-4902633120

### Related issues

- https://github.com/reductstore/reduct-rs/issues/93
- https://github.com/reductstore/reductstore/issues/1487
- https://github.com/reductstore/reductstore/pull/1486

### Does this PR introduce a breaking change?

No. The public API change is additive, and empty prefixes are omitted from create/update payloads to keep existing calls compatible with stable servers.

### Other information:

Local validation:

- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1` against refreshed `reduct/store:latest`
- `RS_API_TOKEN=TOKEN cargo test --features "default,test-api-121" -- --test-threads=1` against refreshed `reduct/store:main`
- `cargo fmt --all -- --check`
- `cargo check`


