### PR TITLE
Add replication compression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add replication destination prefix support, [PR-94](https://github.com/reductstore/reduct-rs/pull/94)
+- Add replication compression setting support, [PR-96](https://github.com/reductstore/reduct-rs/pull/96)
 
 ## 1.20.0 - 2026-06-17
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -557,7 +557,9 @@ YyRIHN8wfdVoOw==
         use super::*;
         use crate::condition;
         use reduct_base::msg::diagnostics::Diagnostics;
-        use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
+        use reduct_base::msg::replication_api::{
+            ReplicationCompression, ReplicationMode, ReplicationSettings,
+        };
 
         #[rstest]
         #[tokio::test]
@@ -704,6 +706,7 @@ YyRIHN8wfdVoOw==
                 each_n: Some(1),
                 when: Some(condition!({"$eq": ["&label", 1]})),
                 mode: ReplicationMode::Enabled,
+                compression: ReplicationCompression::None,
             }
         }
 
@@ -740,6 +743,50 @@ YyRIHN8wfdVoOw==
                 .await
                 .unwrap();
             assert_eq!(replication.settings.dst_prefix, "line-a");
+        }
+
+        #[cfg(feature = "test-api-121")]
+        #[rstest]
+        #[tokio::test]
+        async fn test_replication_compression(
+            #[future] client: ReductClient,
+            mut settings: ReplicationSettings,
+        ) {
+            let client = client.await;
+            client
+                .create_replication("test-replication-compression")
+                .src_bucket(settings.src_bucket.as_str())
+                .dst_bucket(settings.dst_bucket.as_str())
+                .dst_host(settings.dst_host.as_str())
+                .dst_token(settings.dst_token.clone().unwrap_or_default().as_str())
+                .compression(ReplicationCompression::Zstd)
+                .send()
+                .await
+                .unwrap();
+
+            let replication = client
+                .get_replication("test-replication-compression")
+                .await
+                .unwrap();
+            assert_eq!(
+                replication.settings.compression,
+                ReplicationCompression::Zstd
+            );
+
+            settings.compression = ReplicationCompression::Gzip;
+            client
+                .update_replication("test-replication-compression", settings)
+                .await
+                .unwrap();
+
+            let replication = client
+                .get_replication("test-replication-compression")
+                .await
+                .unwrap();
+            assert_eq!(
+                replication.settings.compression,
+                ReplicationCompression::Gzip
+            );
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@ pub use reduct_base::msg::lifecycle_api::{
     LifecycleSettings, LifecycleType,
 };
 pub use reduct_base::msg::replication_api::{
-    FullReplicationInfo, ReplicationInfo, ReplicationList, ReplicationMode, ReplicationModePayload,
-    ReplicationSettings,
+    FullReplicationInfo, ReplicationCompression, ReplicationInfo, ReplicationList, ReplicationMode,
+    ReplicationModePayload, ReplicationSettings,
 };
 pub use reduct_base::msg::server_api::{BucketInfoList, Defaults, ServerInfo};
 pub use reduct_base::msg::status::ResourceStatus;

--- a/src/replication.rs
+++ b/src/replication.rs
@@ -6,7 +6,9 @@
 use crate::client::Result;
 use crate::http_client::HttpClient;
 
-use reduct_base::msg::replication_api::{ReplicationMode, ReplicationSettings};
+use reduct_base::msg::replication_api::{
+    ReplicationCompression, ReplicationMode, ReplicationSettings,
+};
 use reqwest::Method;
 use std::sync::Arc;
 
@@ -104,6 +106,14 @@ impl ReplicationBuilder {
     /// * `mode` - Enabled, Paused, or Disabled.
     pub fn mode(mut self, mode: ReplicationMode) -> Self {
         self.settings.mode = mode;
+        self
+    }
+
+    /// Set replication transfer compression.
+    ///
+    /// * `compression` - None, Zstd, or Gzip.
+    pub fn compression(mut self, compression: ReplicationCompression) -> Self {
+        self.settings.compression = compression;
         self
     }
 


### PR DESCRIPTION
Closes #95

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Re-export `ReplicationCompression` from the Rust SDK public API.
- Add `ReplicationBuilder::compression(...)` for create-replication flows.
- Add v1.21-gated replication compression coverage for creating with `Zstd`, updating to `Gzip`, and reading the setting back from the server.

No user-facing README/example update is included because the repository guidance says not to add examples or README changes for minor features unless explicitly requested.

### Related issues

- Implementation plan: https://github.com/reductstore/reduct-rs/issues/95#issuecomment-4967053190
- Parent rollout: reductstore/reductstore#1547
- Core implementation: reductstore/reductstore#1538

### Does this PR introduce a breaking change?

No. This is additive SDK API surface. Existing callers that omit compression keep using the Core/server default of `none`.

### Other information:

Local validation:

- `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1` against `reduct/store:latest`
- `RS_API_TOKEN=TOKEN cargo test --features "default,test-api-121" -- --test-threads=1` against `reduct/store:main`
- `cargo fmt --all --check`
- `cargo check`
