### PR TITLE
ci: skip S3 cargo cache without credentials

### DIFF
--- a/.github/actions/aws-cargo-cache/action.yml
+++ b/.github/actions/aws-cargo-cache/action.yml
@@ -28,10 +28,28 @@ runs:
           echo "Using preset RUST_MINOR=${RUST_MINOR}"
         fi
 
+    - name: Detect S3 cache credentials
+      id: s3_cache
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.secret-access-key }}
+      run: |
+        if [[ -n "${AWS_ACCESS_KEY_ID}" && -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "S3_CARGO_CACHE_ENABLED=true" >> "$GITHUB_ENV"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "S3_CARGO_CACHE_ENABLED=false" >> "$GITHUB_ENV"
+          echo "S3 Cargo cache is disabled because credentials are unavailable."
+        fi
+
     - name: Install sccache
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Configure sccache
+      if: steps.s3_cache.outputs.enabled == 'true'
       shell: bash
       run: |
         export RUSTC_WRAPPER=sccache
@@ -61,6 +79,7 @@ runs:
         sccache --start-server
 
     - name: Use cache for Cargo downloads
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: runs-on/cache@v4
       with:
         path: |
@@ -79,6 +98,7 @@ runs:
         AWS_DEFAULT_REGION: fsn1
 
     - name: Use cache for Cargo target
+      if: steps.s3_cache.outputs.enabled == 'true'
       uses: runs-on/cache@v4
       with:
         path: target/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,12 @@ jobs:
         run: RS_API_TOKEN=TOKEN cargo test --features ${{ matrix.features }} -- --test-threads=1
 
       - name: Show sccache stats
-        run: sccache --show-stats
+        run: |
+          if command -v sccache >/dev/null 2>&1; then
+            sccache --show-stats
+          else
+            echo "sccache is disabled for this build."
+          fi
 
   sdk_examples:
     name: Client SDK Examples
@@ -94,7 +99,12 @@ jobs:
         run: cargo run --example ${{matrix.example}}
 
       - name: Show sccache stats
-        run: sccache --show-stats
+        run: |
+          if command -v sccache >/dev/null 2>&1; then
+            sccache --show-stats
+          else
+            echo "sccache is disabled for this build."
+          fi
 
   dry_publish:
     runs-on: ubuntu-latest
@@ -119,7 +129,12 @@ jobs:
         run: cargo publish --dry-run -p reduct-rs
 
       - name: Show sccache stats
-        run: sccache --show-stats
+        run: |
+          if command -v sccache >/dev/null 2>&1; then
+            sccache --show-stats
+          else
+            echo "sccache is disabled for this build."
+          fi
 
   check_tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix / CI fix

### What was changed?

- Detect whether S3 cache credentials are available in the shared Cargo cache action.
- Skip S3-backed `sccache` and `runs-on/cache` setup when credentials are missing, allowing fork PRs to run CI without private repository secrets.
- Keep the existing S3 cache behavior for trusted branch and repository runs where secrets are available.
- Make `sccache --show-stats` steps tolerate builds where `sccache` was intentionally skipped.

### Related issues

Same contributor CI failure mode as reductstore/reduct-cli#272: public fork PRs do not receive repository secrets, so S3-backed `sccache` can fail before compilation.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed locally:

- `git diff --check`
- YAML parsing for changed workflow/action files
