### PR TITLE
Add lifecycle processing_interval support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add replication destination prefix support, [PR-94](https://github.com/reductstore/reduct-rs/pull/94)
 - Add replication compression setting support, [PR-96](https://github.com/reductstore/reduct-rs/pull/96)
-- Add lifecycle `processing_interval` setting support, [PR-<id>](https://github.com/reductstore/reduct-rs/pull/<id>)
+- Add lifecycle `processing_interval` setting support, [PR-102](https://github.com/reductstore/reduct-rs/pull/102)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add replication destination prefix support, [PR-94](https://github.com/reductstore/reduct-rs/pull/94)
 - Add replication compression setting support, [PR-96](https://github.com/reductstore/reduct-rs/pull/96)
+- Add lifecycle `processing_interval` setting support, [PR-<id>](https://github.com/reductstore/reduct-rs/pull/<id>)
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ tokio = { version = "1.0", default-features = false, features = ["macros"] }
 [dev-dependencies]
 tokio = { version = "1.0", features = ["test-util", "rt-multi-thread"] }
 rstest = "0.26.1"
-test-with = { version = "0.16.0", default-features = false }
+test-with = { version = ">=0.16.0, <0.16.4", default-features = false }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -74,6 +74,16 @@ impl LifecycleBuilder {
         self
     }
 
+    /// Set the maximum data-time range processed by one lifecycle run.
+    ///
+    /// # Arguments
+    ///
+    /// * `processing_interval` - Processing interval, e.g. "6h", "12h", or "1d".
+    pub fn processing_interval(mut self, processing_interval: &str) -> Self {
+        self.settings.processing_interval = Some(processing_interval.to_string());
+        self
+    }
+
     /// Set the lifecycle conditional query.
     ///
     /// # Arguments
@@ -178,6 +188,7 @@ impl ReductClient {
     ///         .entries(vec!["entry-*".to_string()])
     ///         .older_than("1h")
     ///         .interval("10m")
+    ///         .processing_interval("12h")
     ///         .when(condition!({"$eq": ["&label", 1]}))
     ///         .mode(LifecycleMode::DryRun)
     ///         .send()
@@ -328,6 +339,44 @@ mod tests {
         assert_eq!(lifecycle.settings, settings);
     }
 
+    #[cfg(feature = "test-api-121")]
+    #[rstest]
+    #[tokio::test]
+    async fn test_lifecycle_processing_interval(
+        #[future] client: ReductClient,
+        mut settings: LifecycleSettings,
+    ) {
+        let client = client.await;
+        client
+            .create_lifecycle("test-lifecycle")
+            .lifecycle_type(settings.lifecycle_type)
+            .bucket(settings.bucket.as_str())
+            .entries(settings.entries.clone())
+            .older_than(settings.older_than.as_str())
+            .interval(settings.interval.as_str())
+            .processing_interval("12h")
+            .when(settings.when.clone().unwrap())
+            .mode(settings.mode)
+            .send()
+            .await
+            .unwrap();
+
+        let lifecycle = client.get_lifecycle("test-lifecycle").await.unwrap();
+        assert_eq!(
+            lifecycle.settings.processing_interval,
+            Some("12h".to_string())
+        );
+
+        settings.processing_interval = Some("6h".to_string());
+        client
+            .update_lifecycle("test-lifecycle", settings.clone())
+            .await
+            .unwrap();
+
+        let lifecycle = client.get_lifecycle("test-lifecycle").await.unwrap();
+        assert_eq!(lifecycle.settings, settings);
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_set_lifecycle_mode(#[future] client: ReductClient, settings: LifecycleSettings) {
@@ -398,6 +447,7 @@ mod tests {
             entries: vec![],
             older_than: "1h".to_string(),
             interval: "10m".to_string(),
+            processing_interval: None,
             when: Some(condition!({"$eq": ["&label", 1]})),
             mode: LifecycleMode::Enabled,
         }


### PR DESCRIPTION
Closes #101

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Added `LifecycleBuilder::processing_interval()` so lifecycle create calls can send the ReductStore `processing_interval` API field.
- Updated the lifecycle create example and lifecycle test fixture for the current `LifecycleSettings` shape from `reduct-base`.
- Added a `test-api-121` lifecycle test that creates a policy with `processing_interval`, reads it back, updates it to another value, and verifies the round trip.
- Constrained the `test-with` dev-dependency to `<0.16.4` because `0.16.4` requires Rust 1.95 while this crate declares Rust 1.89 and local validation otherwise selects an incompatible version.

Implementation plan approval: https://github.com/reductstore/reduct-rs/issues/101#issuecomment-5253110494

### Related issues

- https://github.com/reductstore/reduct-rs/issues/101

### Does this PR introduce a breaking change?

No. `processing_interval` is optional and remains unset by default, preserving the existing server-side lifecycle window behavior. Invalid values are still validated by the server, matching existing duration fields.

### Other information:

Local validation:

- With `reduct/store:latest`:
  - `RS_API_TOKEN=TOKEN cargo test lifecycle --features default -- --test-threads=1`
  - `RS_API_TOKEN=TOKEN cargo test --features default -- --test-threads=1`
- With `reduct/store:main`:
  - `RS_API_TOKEN=TOKEN cargo test test_lifecycle_processing_interval --features "default,test-api-121" -- --test-threads=1`
  - `RS_API_TOKEN=TOKEN cargo test --features "default,test-api-121" -- --test-threads=1`
- `cargo fmt --all -- --check`
- `cargo check`

Validation note: the first test attempt failed before compilation because Cargo selected `test-with 0.16.4`, which requires Rust 1.95. The dev-dependency range now excludes that incompatible release.
