### PR TITLE
Enable HTTP/2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add replication destination prefix support, [PR-94](https://github.com/reductstore/reduct-rs/pull/94)
 - Add replication compression setting support, [PR-96](https://github.com/reductstore/reduct-rs/pull/96)
 - Add lifecycle `processing_interval` setting support, [PR-102](https://github.com/reductstore/reduct-rs/pull/102)
+- Enable HTTP/2 support for HTTPS connections, [PR-103](https://github.com/reductstore/reduct-rs/pull/103)
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["lib"]
 reduct-base = { git = "https://github.com/reductstore/reductstore.git", branch = "main" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "cookies"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "cookies", "http2"] }
 http = "1.0.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 bytes = "1.4.0"


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Enable Reqwest's `http2` feature so HTTPS clients advertise HTTP/2 through
ALPN and negotiate it automatically when the server supports it.

Previously, `default-features = false` also disabled Reqwest's default HTTP/2
support. As a result, HTTPS connections remained on HTTP/1.1 and batched query
responses could hit Hyper's 100-header HTTP/1 parser limit.

### Related issues

No related issue.

### Does this PR introduce a breaking change?

No. HTTP/1.1 remains available and is still used when HTTP/2 is not negotiated
or when `ReductClientBuilder::http1_only()` is selected.

### Other information:

Validation:

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test --features default -- --test-threads=1` against `reduct/store:latest`
  (82 passed, 1 ignored; 8 doc tests passed)
- `cargo test --features "default,test-api-121" -- --test-threads=1` against
  `reduct/store:main` (85 passed, 1 ignored; 8 doc tests passed)
- `cargo tree -e features -i h2` confirms the Reqwest, Hyper, Hyper-util, and
  Hyper-rustls HTTP/2 features are enabled.

No dedicated test was added because this is a dependency feature selection;
the existing client suites cover both supported ReductStore versions, while
protocol negotiation itself is handled by Reqwest/Rustls through ALPN.
