### PR TITLE
Add HTTP header limit options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add replication compression setting support, [PR-96](https://github.com/reductstore/reduct-rs/pull/96)
 - Add lifecycle `processing_interval` setting support, [PR-102](https://github.com/reductstore/reduct-rs/pull/102)
 - Enable HTTP/2 support for HTTPS connections, [PR-103](https://github.com/reductstore/reduct-rs/pull/103)
+- Add configurable HTTP/2 response header-list limit, [PR-104](https://github.com/reductstore/reduct-rs/pull/104)
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["lib"]
 reduct-base = { git = "https://github.com/reductstore/reductstore.git", branch = "main" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "cookies", "http2"] }
+reqwest = { version = "0.13.5", default-features = false, features = ["json", "rustls", "stream", "cookies", "http2"] }
 http = "1.0.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 bytes = "1.4.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,7 @@ pub struct ReductClientBuilder {
     api_token: String,
     timeout: Duration,
     http1_only: bool,
+    http2_max_header_list_size: u32,
     verify_ssl: bool,
     ca_cert_path: Option<String>,
 }
@@ -34,6 +35,7 @@ pub struct ReductClientBuilder {
 pub type Result<T> = std::result::Result<T, ReductError>;
 
 pub(super) static API_BASE: &str = "api/v1";
+const DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE: u32 = 512_000;
 
 impl ReductClientBuilder {
     fn new() -> Self {
@@ -42,6 +44,7 @@ impl ReductClientBuilder {
             api_token: String::new(),
             timeout: Duration::from_secs(30),
             http1_only: false,
+            http2_max_header_list_size: DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE,
             verify_ssl: true,
             ca_cert_path: None,
         }
@@ -68,6 +71,7 @@ impl ReductClientBuilder {
         let builder = reqwest::ClientBuilder::new()
             .timeout(self.timeout)
             .cookie_store(true)
+            .http2_max_header_list_size(self.http2_max_header_list_size)
             .danger_accept_invalid_certs(!self.verify_ssl);
         let builder = if let Some(ca_cert_path) = self.ca_cert_path {
             let certs = std::fs::read(&ca_cert_path)
@@ -143,6 +147,15 @@ impl ReductClientBuilder {
     /// Set the HTTP version to HTTP/1.1 only.
     pub fn http1_only(mut self) -> Self {
         self.http1_only = true;
+        self
+    }
+
+    /// Set the maximum size, in bytes, of HTTP/2 response header lists.
+    ///
+    /// The default is 512,000 bytes to match ReductStore's default maximum
+    /// batch metadata size.
+    pub fn http2_max_header_list_size(mut self, size: u32) -> Self {
+        self.http2_max_header_list_size = size;
         self
     }
 
@@ -422,6 +435,18 @@ pub(crate) mod tests {
         fn test_build_client(#[case] url: &str, #[case] expected_url: &str) {
             let client = ReductClient::builder().url(url).build();
             assert_eq!(client.url(), expected_url);
+        }
+
+        #[test]
+        fn test_http2_max_header_list_size() {
+            let builder = ReductClient::builder();
+            assert_eq!(
+                builder.http2_max_header_list_size,
+                DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE
+            );
+
+            let builder = builder.http2_max_header_list_size(1_000_000);
+            assert_eq!(builder.http2_max_header_list_size, 1_000_000);
         }
 
         #[rstest]

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,7 @@ pub struct ReductClientBuilder {
     api_token: String,
     timeout: Duration,
     http1_only: bool,
+    http1_max_headers: usize,
     http2_max_header_list_size: u32,
     verify_ssl: bool,
     ca_cert_path: Option<String>,
@@ -35,6 +36,7 @@ pub struct ReductClientBuilder {
 pub type Result<T> = std::result::Result<T, ReductError>;
 
 pub(super) static API_BASE: &str = "api/v1";
+const DEFAULT_HTTP1_MAX_HEADERS: usize = 1_024;
 const DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE: u32 = 512_000;
 
 impl ReductClientBuilder {
@@ -44,6 +46,7 @@ impl ReductClientBuilder {
             api_token: String::new(),
             timeout: Duration::from_secs(30),
             http1_only: false,
+            http1_max_headers: DEFAULT_HTTP1_MAX_HEADERS,
             http2_max_header_list_size: DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE,
             verify_ssl: true,
             ca_cert_path: None,
@@ -71,6 +74,7 @@ impl ReductClientBuilder {
         let builder = reqwest::ClientBuilder::new()
             .timeout(self.timeout)
             .cookie_store(true)
+            .http1_max_headers(self.http1_max_headers)
             .http2_max_header_list_size(self.http2_max_header_list_size)
             .danger_accept_invalid_certs(!self.verify_ssl);
         let builder = if let Some(ca_cert_path) = self.ca_cert_path {
@@ -147,6 +151,14 @@ impl ReductClientBuilder {
     /// Set the HTTP version to HTTP/1.1 only.
     pub fn http1_only(mut self) -> Self {
         self.http1_only = true;
+        self
+    }
+
+    /// Set the maximum number of headers accepted in an HTTP/1 response.
+    ///
+    /// The default is 1,024 headers to support large ReductStore record batches.
+    pub fn http1_max_headers(mut self, max: usize) -> Self {
+        self.http1_max_headers = max;
         self
     }
 
@@ -447,6 +459,15 @@ pub(crate) mod tests {
 
             let builder = builder.http2_max_header_list_size(1_000_000);
             assert_eq!(builder.http2_max_header_list_size, 1_000_000);
+        }
+
+        #[test]
+        fn test_http1_max_headers() {
+            let builder = ReductClient::builder();
+            assert_eq!(builder.http1_max_headers, DEFAULT_HTTP1_MAX_HEADERS);
+
+            let builder = builder.http1_max_headers(2_048);
+            assert_eq!(builder.http1_max_headers, 2_048);
         }
 
         #[rstest]


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Add `ReductClientBuilder::http1_max_headers` and
`ReductClientBuilder::http2_max_header_list_size` so applications can
configure the limits used when parsing HTTP response headers.

Raise the HTTP/1 default from Hyper's 100 headers to 1,024 headers, and the
HTTP/2 default from Hyper's 16 KiB to 512,000 bytes. The HTTP/2 default matches
ReductStore's default maximum batch metadata size. These defaults allow
conditional queries using larger `#batch_records` values to return their
record metadata over either protocol.

### Related issues

Follow-up to https://github.com/reductstore/reduct-rs/pull/103.

### Does this PR introduce a breaking change?

No. Existing builder calls keep working. Applications may lower or raise the
new limit explicitly when needed.

### Other information:

Validation:

- `cargo fmt --all -- --check`
- `cargo check`
- Builder tests, including the new default/override coverage
- Full SDK suite against `reduct/store:latest` (84 passed, 1 ignored; 8 doc tests passed)
- Full SDK suite against `reduct/store:main` (87 passed, 1 ignored; 8 doc tests passed)
